### PR TITLE
Implement GM speed command, and make GM invis command actually toggle invis status.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -120,3 +120,4 @@ These GM commands are implemented in the FFXIV protocol, but only some of them a
 * `//gm item <id>`: Gives yourself an item. This can only place a single item in the first page of your inventory currently.
 * `//gm lv <level>`: Sets your current level
 * `//gm aetheryte <on/off> <id>`: Unlock an Aetheryte.
+* `//gm speed <multiplier>`: Increases your movement speed by `multiplier`.

--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -568,15 +568,27 @@ async fn client_loop(
                                                     GameMasterCommandType::ChangeWeather => {
                                                         connection.change_weather(*arg0 as u16).await
                                                     }
+                                                    GameMasterCommandType::Speed => {
+                                                        // TODO: Maybe allow setting the speed of a targeted player too?
+                                                        connection
+                                                        .actor_control_self(ActorControlSelf {
+                                                            category:
+                                                            ActorControlCategory::Flee {
+                                                                speed: *arg0 as u16,
+                                                            },
+                                                        })
+                                                        .await
+                                                    }
                                                     GameMasterCommandType::ChangeTerritory => {
                                                         connection.change_zone(*arg0 as u16).await
                                                     }
                                                     GameMasterCommandType::ToggleInvisibility => {
+                                                        connection.player_data.gm_invisible = !connection.player_data.gm_invisible;
                                                         connection
                                                         .actor_control_self(ActorControlSelf {
                                                             category:
                                                             ActorControlCategory::ToggleInvisibility {
-                                                                invisible: true,
+                                                                invisible: connection.player_data.gm_invisible,
                                                             },
                                                         })
                                                         .await

--- a/src/ipc/zone/actor_control.rs
+++ b/src/ipc/zone/actor_control.rs
@@ -69,6 +69,11 @@ pub enum ActorControlCategory {
         insufficient_gil: u32,
         aetheryte_id: u32,
     },
+    #[brw(magic=0x1Bu16)]
+    Flee {
+        #[brw(pad_before = 2)] // padding
+        speed: u16,
+    }
 }
 
 #[binrw]

--- a/src/ipc/zone/mod.rs
+++ b/src/ipc/zone/mod.rs
@@ -140,6 +140,7 @@ impl Default for ServerZoneIpcSegment {
 pub enum GameMasterCommandType {
     SetLevel = 0x1,
     ChangeWeather = 0x6,
+    Speed = 0x9,
     ToggleInvisibility = 0xD,
     ToggleWireframe = 0x26,
     ChangeTerritory = 0x58,

--- a/src/world/connection.rs
+++ b/src/world/connection.rs
@@ -61,6 +61,7 @@ pub struct PlayerData {
 
     pub teleport_query: TeleportQuery,
     pub gm_rank: GameMasterRank,
+    pub gm_invisible: bool,
 }
 
 /// Represents a single connection between an instance of the client and the world server


### PR DESCRIPTION
Called the speed category Flee to stay consistent with other sources such as Sapphire and ffxiv_reverse, but the actual command is called Speed (e.g. `//gm speed 2`).

Video of `//gm invis`:

https://github.com/user-attachments/assets/66f10204-30c9-4311-b42b-c54b63356eb6

Video of `//gm speed`:

https://github.com/user-attachments/assets/8855b173-3dd1-471b-bdf2-82c656eef6c4

