### PR TITLE
Stop the world server from becoming upset when a Lua command is invoked with no arguments.

### DIFF
--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -538,10 +538,15 @@ async fn client_loop(
                                                                 let func: Function =
                                                                 lua.globals().get("onCommand").unwrap();
 
-                                                                tracing::info!("{}", &chat_message.message[command_name.len() + 2..]);
-
-                                                                func.call::<()>((&chat_message.message[command_name.len() + 2..], connection_data))
-                                                                .unwrap();
+                                                                let mut func_args = "";
+                                                                if parts.len() > 1 {
+                                                                    func_args = &chat_message.message[command_name.len() + 2..];
+                                                                    tracing::info!("Args passed to Lua command {}: {}", command_name, func_args);
+                                                                } else {
+                                                                    tracing::info!("No additional args passed to Lua command {}.", command_name);
+                                                                }
+                                                                func.call::<()>((func_args, connection_data)).
+                                                                unwrap();
 
                                                                 Ok(())
                                                             })


### PR DESCRIPTION
Allows commands that have a default set of arg(s) to use those when none are specified, as well as allowing commands to act as toggles (such as a wireframe toggle, or disabling any set festivals).

This is probably not the most elegant or ideal fix, but my Rust knowledge is a little limited here, so I worked with what I could figure out.

While I was here, I also made the trace message a little more verbose since it was confusing seeing random parameters in the server log with no further indication as to what they were.