### PR TITLE
Add a basic permission system to Lua scripts to bring them in line with in-game GM commands.

### DIFF
--- a/resources/scripts/Global.lua
+++ b/resources/scripts/Global.lua
@@ -3,6 +3,10 @@ function onBeginLogin(player)
     player:send_message("Welcome to Kawari!")
 end
 
+function onCommandPermissionError(player)
+    player:send_message("You do not have permission to run this command.")
+end
+
 function split(input, separator)
     if separator == nil then
         separator = '%s'
@@ -15,6 +19,17 @@ function split(input, separator)
 
     return t
 end
+
+-- Constants
+GM_RANK_NORMALUSER = 0
+GM_RANK_GAMEMASTER = 1
+GM_RANK_EVENTJUNIOR = 3
+GM_RANK_EVENTSENIOR = 4
+GM_RANK_SUPPORT = 5
+GM_RANK_SENIOR = 7
+GM_RANK_DEBUG = 90
+GM_RANK_MAX = 255 -- Doesn't exist, used for purposes of testing permissions in scripts
+
 
 -- please keep these ids sorted!
 
@@ -51,3 +66,4 @@ registerCommand("classjob", "commands/debug/ClassJob.lua")
 registerCommand("setspeed", "commands/debug/SetSpeed.lua")
 registerCommand("nudge", "commands/debug/Nudge.lua")
 registerCommand("festival", "commands/debug/Festival.lua")
+registerCommand("permtest", "commands/debug/PermissionTest.lua")

--- a/resources/scripts/Global.lua
+++ b/resources/scripts/Global.lua
@@ -3,8 +3,14 @@ function onBeginLogin(player)
     player:send_message("Welcome to Kawari!")
 end
 
-function onCommandPermissionError(player)
+function onCommandRequiredRankInsufficientError(player)
     player:send_message("You do not have permission to run this command.")
+end
+
+function onCommandRequiredRankMissingError(additional_information, player)
+    local error_msg = "Your script does not define the required_rank variable. Please define it in your script for it to run."
+
+    player:send_message(string.format("%s\nAdditional information: %s", error_msg, additional_information))
 end
 
 function split(input, separator)

--- a/resources/scripts/commands/debug/ClassJob.lua
+++ b/resources/scripts/commands/debug/ClassJob.lua
@@ -1,3 +1,5 @@
+permissions = GM_RANK_DEBUG
+
 function onCommand(args, player)
     local parts = split(args)
     player:set_classjob(parts[1])

--- a/resources/scripts/commands/debug/ClassJob.lua
+++ b/resources/scripts/commands/debug/ClassJob.lua
@@ -1,4 +1,4 @@
-permissions = GM_RANK_DEBUG
+required_rank = GM_RANK_DEBUG
 
 function onCommand(args, player)
     local parts = split(args)

--- a/resources/scripts/commands/debug/Festival.lua
+++ b/resources/scripts/commands/debug/Festival.lua
@@ -1,6 +1,6 @@
 -- A list of festival ids can be found in Hyperborea's source tree:
 -- https://github.com/kawaii/Hyperborea/blob/main/Hyperborea/festivals.yaml
-permissions = GM_RANK_DEBUG
+required_rank = GM_RANK_DEBUG
 
 function onCommand(args, player)
     local parts = split(args)

--- a/resources/scripts/commands/debug/Festival.lua
+++ b/resources/scripts/commands/debug/Festival.lua
@@ -1,5 +1,6 @@
 -- A list of festival ids can be found in Hyperborea's source tree:
 -- https://github.com/kawaii/Hyperborea/blob/main/Hyperborea/festivals.yaml
+permissions = GM_RANK_DEBUG
 
 function onCommand(args, player)
     local parts = split(args)

--- a/resources/scripts/commands/debug/Nudge.lua
+++ b/resources/scripts/commands/debug/Nudge.lua
@@ -1,6 +1,6 @@
 -- Ported from Ioncannon's Project Meteor Server 
 -- https://bitbucket.org/Ioncannon/project-meteor-server/src/develop/Data/scripts/commands/gm/nudge.lua
-permissions = GM_RANK_DEBUG
+required_rank = GM_RANK_DEBUG
 
 function send_msg(message, player)
     player:send_message(string.format("[nudge] %s", message))

--- a/resources/scripts/commands/debug/Nudge.lua
+++ b/resources/scripts/commands/debug/Nudge.lua
@@ -1,6 +1,6 @@
 -- Ported from Ioncannon's Project Meteor Server 
 -- https://bitbucket.org/Ioncannon/project-meteor-server/src/develop/Data/scripts/commands/gm/nudge.lua
-permissions = GM_RANK_MAX
+permissions = GM_RANK_DEBUG
 
 function send_msg(message, player)
     player:send_message(string.format("[nudge] %s", message))

--- a/resources/scripts/commands/debug/Nudge.lua
+++ b/resources/scripts/commands/debug/Nudge.lua
@@ -1,5 +1,6 @@
 -- Ported from Ioncannon's Project Meteor Server 
 -- https://bitbucket.org/Ioncannon/project-meteor-server/src/develop/Data/scripts/commands/gm/nudge.lua
+permissions = GM_RANK_MAX
 
 function send_msg(message, player)
     player:send_message(string.format("[nudge] %s", message))

--- a/resources/scripts/commands/debug/PermissionTest.lua
+++ b/resources/scripts/commands/debug/PermissionTest.lua
@@ -1,4 +1,4 @@
-permissions = GM_RANK_MAX
+required_rank = GM_RANK_MAX
 
 function onCommand(args, player)
     player:send_message("How did you run this? This shouldn't be runnable!")

--- a/resources/scripts/commands/debug/PermissionTest.lua
+++ b/resources/scripts/commands/debug/PermissionTest.lua
@@ -1,0 +1,5 @@
+permissions = GM_RANK_MAX
+
+function onCommand(args, player)
+    player:send_message("How did you run this? This shouldn't be runnable!")
+end

--- a/resources/scripts/commands/debug/SetPos.lua
+++ b/resources/scripts/commands/debug/SetPos.lua
@@ -1,4 +1,4 @@
-permissions = GM_RANK_DEBUG
+required_rank = GM_RANK_DEBUG
 
 function onCommand(args, player)
     local parts = split(args)

--- a/resources/scripts/commands/debug/SetPos.lua
+++ b/resources/scripts/commands/debug/SetPos.lua
@@ -1,3 +1,5 @@
+permissions = GM_RANK_DEBUG
+
 function onCommand(args, player)
     local parts = split(args)
     player:set_position({ x = tonumber(parts[1]), y = tonumber(parts[2]), z = tonumber(parts[3]) }, 0)

--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -552,7 +552,8 @@ async fn client_loop(
                                                                     unwrap();
                                                                     Ok(())
                                                                 } else {
-                                                                    tracing::info!("User with account_id {} tried to invoke GM command they have no permissions for!!!", connection.player_data.account_id);
+                                                                    tracing::info!("User with account_id {} tried to invoke GM command {} they have no permissions for!",
+                                                                    connection.player_data.account_id, command_name);
                                                                     let func: Function =
                                                                     lua.globals().get("onCommandPermissionError").unwrap();
                                                                     func.call::<()>(connection_data).unwrap();


### PR DESCRIPTION
Pretty self-explanatory, but it allows Lua scripts to now set how permissive they want to be based on the player's GM rank. Also included is a test script (PermissionTest.lua) which will fail even for rank 90 characters.