### PR TITLE
Apply a temporary-ish fix so that not all chat messages appear as unknown commands.

### DIFF
--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -498,6 +498,8 @@ async fn client_loop(
                                                 connection.handle.send(ToServer::Message(connection.id, chat_message.message.clone())).await;
 
                                                 let mut handled = false;
+                                                let command_trigger: char = '!';
+                                                if chat_message.message.starts_with(command_trigger)
                                                 {
                                                     let parts: Vec<&str> = chat_message.message.split(' ').collect();
                                                     let command_name = &parts[0][1..];


### PR DESCRIPTION
Since bb2cc9e0ec4479cb, all chat messages appear as unknown commands. For now, this is a simple workaround to stop false positives.