### PR TITLE
Further reduce boilerplate in various scripts

### DIFF
--- a/resources/scripts/Global.lua
+++ b/resources/scripts/Global.lua
@@ -24,6 +24,21 @@ function getTableSize(tbl)
     return count
 end
 
+function printf(player, fmt_str, ...)
+    -- Sender would be defined elsewhere, if at all
+    if sender == nil then
+        sender = ""
+    end
+
+    if ... ~= nil then
+        player:send_message(sender..fmt_str:format(...))
+    else
+        player:send_message(sender..fmt_str)
+    end
+
+    sender = nil -- Reset the sender, it's not required to have for printf to work, and not all users of printf will be commands, most likely.
+end
+
 -- Constants
 GM_RANK_NORMALUSER = 0
 GM_RANK_GAMEMASTER = 1

--- a/resources/scripts/Global.lua
+++ b/resources/scripts/Global.lua
@@ -26,17 +26,15 @@ end
 
 function printf(player, fmt_str, ...)
     -- Sender would be defined elsewhere, if at all
-    if sender == nil then
-        sender = ""
+    if command_sender == nil then
+        command_sender = ""
     end
 
     if ... ~= nil then
-        player:send_message(sender..fmt_str:format(...))
+        player:send_message(command_sender..fmt_str:format(...))
     else
-        player:send_message(sender..fmt_str)
+        player:send_message(command_sender..fmt_str)
     end
-
-    sender = nil -- Reset the sender, it's not required to have for printf to work, and not all users of printf will be commands, most likely.
 end
 
 -- Constants

--- a/resources/scripts/Init.lua
+++ b/resources/scripts/Init.lua
@@ -18,10 +18,9 @@ end
 
 function onCommandRequiredRankMissingError(additional_information, player)
     local error_msg = "Your script does not define the required_rank variable. Please define it in your script for it to run."
-
-    player:send_message(string.format("%s\nAdditional information: %s", error_msg, additional_information))
+    printf(player, "%s\nAdditional information: %s", error_msg, additional_information)
 end
 
 function onUnknownCommandError(command_name, player)
-    player:send_message(string.format("Unknown command %s", command_name))
+    printf(player, "Unknown command %s", command_name)
 end

--- a/resources/scripts/commands/debug/ChangeTerritory.lua
+++ b/resources/scripts/commands/debug/ChangeTerritory.lua
@@ -1,22 +1,23 @@
 required_rank = GM_RANK_DEBUG
+sender = "[teri] "
 
 function onCommand(args, player)
     local parts = split(args)
     local argc = #parts
-    local sender = "[teri] "
     local usage = "\nThis command moves the user to a new zone/territory.\nUsage: !teri <id>"
 
     if argc == 0 then
-        player:send_message(sender.."A territory id is required to use this command."..usage)
+        printf(player, "A territory id is required to use this command."..usage)
+        return
     end
 
     local id = tonumber(parts[1])
 
     if not id or id < 0 or id > 65535 then -- Must be in range of unsigned 16-bit value
-        player:send_message(sender.."Error parsing territory id! Make sure your input is an integer between 0 and 65535."..usage)
+        printf(player, "Error parsing territory id! Make sure your input is an integer between 0 and 65535."..usage)
         return
     end
 
     player:change_territory(id)
-    player:send_message(string.format("%s Changing territory to %s.", sender, id))
+    printf(player, "Changing territory to %s.", id)
 end

--- a/resources/scripts/commands/debug/ChangeTerritory.lua
+++ b/resources/scripts/commands/debug/ChangeTerritory.lua
@@ -1,5 +1,5 @@
 required_rank = GM_RANK_DEBUG
-sender = "[teri] "
+command_sender = "[teri] "
 
 function onCommand(args, player)
     local parts = split(args)

--- a/resources/scripts/commands/debug/Festival.lua
+++ b/resources/scripts/commands/debug/Festival.lua
@@ -1,7 +1,7 @@
 -- A list of festival ids can be found in Hyperborea's source tree:
 -- https://github.com/kawaii/Hyperborea/blob/main/Hyperborea/festivals.yaml
 required_rank = GM_RANK_DEBUG
-sender = "[festival] "
+command_sender = "[festival] "
 
 function onCommand(args, player)
     local parts = split(args)

--- a/resources/scripts/commands/debug/Festival.lua
+++ b/resources/scripts/commands/debug/Festival.lua
@@ -1,35 +1,18 @@
 -- A list of festival ids can be found in Hyperborea's source tree:
 -- https://github.com/kawaii/Hyperborea/blob/main/Hyperborea/festivals.yaml
 required_rank = GM_RANK_DEBUG
+sender = "[festival] "
 
 function onCommand(args, player)
     local parts = split(args)
     local argc = #parts
     local usage = "\nUsage: !festival <id1> <id2> <id3> <id4>"
-    local sender = "[festival] "
 
-    local id1 = tonumber(parts[1])
-    local id2 = tonumber(parts[2])
-    local id3 = tonumber(parts[3])
-    local id4 = tonumber(parts[4])
-
-    if not id1 then
-        id1 = 0
-    end
-
-    if not id2 then
-        id2 = 0
-    end
-
-    if not id3 then
-        id3 = 0
-    end
-
-    if not id4 then
-        id4 = 0
-    end
+    local id1 = tonumber(parts[1]) or 0
+    local id2 = tonumber(parts[2]) or 0
+    local id3 = tonumber(parts[3]) or 0
+    local id4 = tonumber(parts[4]) or 0
 
     player:set_festival(id1, id2, id3, id4)
-    local message = string.format("Festival(s) changed to %s, %s, %s and %s.", id1, id2, id3, id4)
-    player:send_message(message)
+    printf(player, "Festival(s) changed to %s, %s, %s and %s.", id1, id2, id3, id4)
 end

--- a/resources/scripts/commands/debug/Nudge.lua
+++ b/resources/scripts/commands/debug/Nudge.lua
@@ -1,10 +1,7 @@
 -- Ported from Ioncannon's Project Meteor Server 
 -- https://bitbucket.org/Ioncannon/project-meteor-server/src/develop/Data/scripts/commands/gm/nudge.lua
 required_rank = GM_RANK_DEBUG
-
-function send_msg(message, player)
-    player:send_message(string.format("[nudge] %s", message))
-end
+sender = "[nudge] "
 
 function onCommand(args, player)
     local parts = split(args)
@@ -33,7 +30,7 @@ function onCommand(args, player)
         if checkArg1 then
             distance = checkArg1
         else
-            send_msg("Error parsing distance! \n"..usage, player)
+            printf(player, "Error parsing distance!\n"..usage)
             return
         end
     end
@@ -46,11 +43,11 @@ function onCommand(args, player)
             if vertical[string.upper(arg2)] then  -- Check vertical direction on string, otherwise throw param error
                 direction = vertical[string.upper(arg2)]
             else
-                send_msg("Error parsing direction! \n"..usage, player)
+                printf(player, "Error parsing direction! \n"..usage)
                 return
             end
         else
-            send_msg("Error parsing parameters! \n"..usage, player)
+            printf(player, "Error parsing parameters! \n"..usage)
             return
         end
     end
@@ -73,6 +70,5 @@ function onCommand(args, player)
     end
 
     player:set_position(new_position, player.rotation)
-    local message = string.format("Positioning %s %s yalms.", direction_str, distance)
-    send_msg(message, player)
+    printf(player, "Positioning %s %s yalms.", direction_str, distance)
 end

--- a/resources/scripts/commands/debug/Nudge.lua
+++ b/resources/scripts/commands/debug/Nudge.lua
@@ -1,7 +1,7 @@
 -- Ported from Ioncannon's Project Meteor Server 
 -- https://bitbucket.org/Ioncannon/project-meteor-server/src/develop/Data/scripts/commands/gm/nudge.lua
 required_rank = GM_RANK_DEBUG
-sender = "[nudge] "
+command_sender = "[nudge] "
 
 function onCommand(args, player)
     local parts = split(args)
@@ -70,5 +70,6 @@ function onCommand(args, player)
     end
 
     player:set_position(new_position, player.rotation)
+
     printf(player, "Positioning %s %s yalms.", direction_str, distance)
 end

--- a/resources/scripts/commands/debug/SetSpeed.lua
+++ b/resources/scripts/commands/debug/SetSpeed.lua
@@ -1,15 +1,15 @@
 required_rank = GM_RANK_DEBUG
+sender = "[setspeed] "
 
 function onCommand(args, player)
     local parts = split(args)
     local argc = #parts
-    local sender = "[setspeed] "
     local usage = "\nThis command sets the user's speed to a desired multiplier.\nUsage: !setspeed <multiplier>"
     local SPEED_MAX = 10 -- Arbitrary, but it's more or less unplayable even at this amount
     local speed_multiplier = tonumber(parts[1])
 
     if argc == 1 and not speed_multiplier then
-        player:send_message(sender.."Error parsing speed multiplier! Make sure the multiplier is an integer."..usage)
+        printf(player, "Error parsing speed multiplier! Make sure the multiplier is an integer."..usage)
         return
     elseif argc == 0 then
         speed_multiplier = 1
@@ -22,5 +22,5 @@ function onCommand(args, player)
     end
 
     player:set_speed(speed_multiplier)
-    player:send_message(string.format("%sSpeed multiplier set to %s.", sender, speed_multiplier))
+    printf(player, "Speed multiplier set to %s.", speed_multiplier)
 end

--- a/resources/scripts/commands/debug/SetSpeed.lua
+++ b/resources/scripts/commands/debug/SetSpeed.lua
@@ -1,5 +1,5 @@
 required_rank = GM_RANK_DEBUG
-sender = "[setspeed] "
+command_sender = "[setspeed] "
 
 function onCommand(args, player)
     local parts = split(args)

--- a/resources/scripts/commands/debug/ToggleInvisibility.lua
+++ b/resources/scripts/commands/debug/ToggleInvisibility.lua
@@ -1,5 +1,5 @@
 required_rank = GM_RANK_DEBUG
-sender = "[invis] "
+command_sender = "[invis] "
 
 function onCommand(args, player)
     local usage = "\nThis command makes the user invisible to all other actors."

--- a/resources/scripts/commands/debug/ToggleInvisibility.lua
+++ b/resources/scripts/commands/debug/ToggleInvisibility.lua
@@ -1,9 +1,9 @@
 required_rank = GM_RANK_DEBUG
+sender = "[invis] "
 
 function onCommand(args, player)
-    local sender = "[invis] "
     local usage = "\nThis command makes the user invisible to all other actors."
 
     player:toggle_invisibility()
-    player:send_message(sender.."Invisibility toggled.")
+    printf(player, "Invisibility toggled.")
 end

--- a/resources/scripts/commands/debug/ToggleWireframe.lua
+++ b/resources/scripts/commands/debug/ToggleWireframe.lua
@@ -1,5 +1,5 @@
 required_rank = GM_RANK_DEBUG
-sender = "[wireframe] "
+command_sender = "[wireframe] "
 
 function onCommand(args, player)
     local usage = "\nThis command allows the user to view the world in wireframe mode."

--- a/resources/scripts/commands/debug/ToggleWireframe.lua
+++ b/resources/scripts/commands/debug/ToggleWireframe.lua
@@ -1,9 +1,9 @@
 required_rank = GM_RANK_DEBUG
+sender = "[wireframe] "
 
 function onCommand(args, player)
-    local sender = "[wireframe] "
     local usage = "\nThis command allows the user to view the world in wireframe mode."
 
     player:toggle_wireframe()
-    player:send_message(sender.."Wireframe mode toggled.")
+    printf(player, "Wireframe mode toggled.")
 end

--- a/resources/scripts/commands/debug/Unlock.lua
+++ b/resources/scripts/commands/debug/Unlock.lua
@@ -1,5 +1,5 @@
 required_rank = GM_RANK_DEBUG
-sender = "[unlockaction] "
+command_sender = "[unlockaction] "
 
 function onCommand(args, player)
     local parts = split(args)

--- a/resources/scripts/commands/debug/Unlock.lua
+++ b/resources/scripts/commands/debug/Unlock.lua
@@ -1,13 +1,14 @@
 required_rank = GM_RANK_DEBUG
+sender = "[unlockaction] "
 
 function onCommand(args, player)
     local parts = split(args)
     local argc = #parts
-    local sender = "[unlockaction] "
+
     local usage = "\nThis command teaches the user an action, emote, etc.\nUsage: !useaction <id/all>"
 
     if argc < 1 then
-        player:send_message(sender.."This command requires 1 parameter."..usage)
+        printf(player, "This command requires 1 parameter."..usage)
         return
     end
 
@@ -15,16 +16,16 @@ function onCommand(args, player)
         for i = 0, 1000, 1 do
             player:unlock_action(i)
         end
-        player:send_message(string.format("%s Everything is unlocked!", sender, id))
+        printf(player, "Everything is unlocked!", id)
     else
         local id = tonumber(parts[1])
 
         if not id then
-            player:send_message(sender.."Error parsing action id! Make sure the id is an integer."..usage)
+            printf(player, "Error parsing action id! Make sure the id is an integer."..usage)
             return
         end
 
         player:unlock_action(id)
-        player:send_message(string.format("%s Action %s unlocked!", sender, id))
+        printf(player, "Action %s unlocked!", id)
     end
 end

--- a/resources/scripts/commands/debug/UnlockAetheryte.lua
+++ b/resources/scripts/commands/debug/UnlockAetheryte.lua
@@ -1,5 +1,5 @@
 required_rank = GM_RANK_DEBUG
-sender = "[unlockaetheryte] "
+command_sender = "[unlockaetheryte] "
 
 function onCommand(args, player)
     local parts = split(args)

--- a/resources/scripts/commands/debug/UnlockAetheryte.lua
+++ b/resources/scripts/commands/debug/UnlockAetheryte.lua
@@ -1,13 +1,13 @@
 required_rank = GM_RANK_DEBUG
+sender = "[unlockaetheryte] "
 
 function onCommand(args, player)
     local parts = split(args)
     local argc = #parts
-    local sender = "[unlockaetheryte] "
     local usage = "\nThis command unlocks an aetheryte for the user.\nUsage: !unlockaetheryte <on/off> <id>"
 
     if argc < 2 then
-        player:send_message(sender.."This command requires two parameters."..usage)
+        printf(player, "This command requires two parameters."..usage)
         return
     end
 
@@ -18,7 +18,7 @@ function onCommand(args, player)
     elseif on == "off" then
         on = 1
     else
-        player:send_message(sender.."Error parsing first parameter. Must be either of the words: 'on' or 'off'."..usage)
+        printf(player, "Error parsing first parameter. Must be either of the words: 'on' or 'off'."..usage)
         return
     end
 
@@ -29,11 +29,11 @@ function onCommand(args, player)
         if id == "all" then
             id = 0
         else
-            player:send_message(sender.."Error parsing id parameter. Must be an aetheryte id or the word 'all'."..usage)
+            printf(player, "Error parsing id parameter. Must be an aetheryte id or the word 'all'."..usage)
             return
         end
     end
 
     player:unlock_aetheryte(on, id)
-    player:send_message(string.format("%s Aetheryte(s) %s had their unlocked status changed!", sender, id))
+    printf(player, "Aetheryte(s) %s had their unlocked status changed!", id)
 end

--- a/resources/scripts/events/Events.lua
+++ b/resources/scripts/events/Events.lua
@@ -273,7 +273,7 @@ to_sort = {
     [1179657] = "Chocobokeep.lua", -- Chocobokeep in Central Shroud
 }
 
--- Events in /common that aren't already get covered by other tables
+-- Events in /common that aren't already covered by other tables
 common_events = {
     [720915] = "GenericMender.lua",
 }

--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -562,7 +562,6 @@ async fn client_loop(
                                                                          */
                                                                         let command_sender: Result<mlua::prelude::LuaValue, mlua::prelude::LuaError> = lua.globals().get("command_sender");
                                                                         if let Ok(_) = command_sender {
-                                                                            // tracing::info!("Resetting command_sender for next script run.");
                                                                             lua.globals().set("command_sender", mlua::Value::Nil)?;
                                                                         }
                                                                         Ok(())

--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -555,6 +555,16 @@ async fn client_loop(
                                                                         let func: Function =
                                                                             lua.globals().get("onCommand")?;
                                                                         func.call::<()>((func_args, connection_data))?;
+
+                                                                        /* `command_sender` is an optional variable scripts can define to identify themselves in print messages.
+                                                                         * It's okay if this global isn't set. We also don't care what its value is, just that it exists.
+                                                                         * This is reset -after- running the command intentionally. Resetting beforehand will never display the command's identifier.
+                                                                         */
+                                                                        let command_sender: Result<mlua::prelude::LuaValue, mlua::prelude::LuaError> = lua.globals().get("command_sender");
+                                                                        if let Ok(_) = command_sender {
+                                                                            // tracing::info!("Resetting command_sender for next script run.");
+                                                                            lua.globals().set("command_sender", mlua::Value::Nil)?;
+                                                                        }
                                                                         Ok(())
                                                                     } else {
                                                                         tracing::info!("User with account_id {} tried to invoke GM command {} with insufficient privileges!",


### PR DESCRIPTION
Introduce a printf helper command which can print the sending command's name for you (via "command_sender", an optional variable scripts can define to identify themselves with when sending messages to the chat log), and treats the message as a format string if additional params follow.

Support was also added on the Rust side for "command_sender".