### PR TITLE
Use `raw-dylib` when linking to Oodle on Windows

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -26,7 +26,7 @@ Windows and Linux artifacts are built on every commit, under [Github Actions](ht
 
 Build Kawari with `cargo build`.
 
-For the World server to function, Kawari needs to be built with `--features oodle`. Place the `oodle-network-shared.lib` (Windows) or `oodle-network-shared.so` (Linux) in a folder created by you named `oodle` before building.
+For the World server to function, Kawari needs to be built with `--features oodle`. On Linux, place the `oodle-network-shared.so` in a folder created by you named `oodle` before building.
 
 ## Setup
 

--- a/src/packet/oodle.rs
+++ b/src/packet/oodle.rs
@@ -7,7 +7,8 @@
 use std::{ffi::c_void, ptr::null};
 
 #[cfg(feature = "oodle")]
-#[link(name = "oodle-network-shared")]
+#[cfg_attr(windows, link(name = "oodle-network-shared", kind = "raw-dylib"))]
+#[cfg_attr(not(windows), link(name = "oodle-network-shared"))]
 unsafe extern "C" {
     pub fn OodleNetwork1TCP_State_Size() -> isize;
     pub fn OodleNetwork1_Shared_Size(htbits: i32) -> isize;


### PR DESCRIPTION
This means that the static .lib is no longer required at compile time, but the .dll is still required at runtime. On Linux, the .so is still required at both compile time and runtime, because linking works differently there.

I haven't tested this on Linux, so please do that first!