### PR TITLE
Fix cargo test compilation

### DIFF
--- a/src/packet/parsing.rs
+++ b/src/packet/parsing.rs
@@ -252,6 +252,10 @@ mod tests {
             fn get_name(&self) -> &'static str {
                 todo!()
             }
+
+            fn get_opcode(&self) -> u16 {
+                todo!()
+            }
         }
 
         let packet_types = [


### PR DESCRIPTION
Fixes error:

error[E0046]: not all trait items implemented, missing: `get_opcode`
   --> src/packet/parsing.rs:247:9
    |
247 |         impl ReadWriteIpcSegment for ClientLobbyIpcSegment {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `get_opcode` in implementation
