### PR TITLE
Inventory and equip command: fix the opcode to discard items, document moving and exchanging items, and fix a bug in the !equip command

### DIFF
--- a/src/inventory/item.rs
+++ b/src/inventory/item.rs
@@ -1,3 +1,4 @@
+use crate::ITEM_CONDITION_MAX;
 use serde::{Deserialize, Serialize};
 
 /// Represents an item, or if the quanity is zero an empty slot.
@@ -14,7 +15,7 @@ impl Item {
         Self {
             quantity,
             id,
-            condition: 30000,
+            condition: ITEM_CONDITION_MAX,
             ..Default::default()
         }
     }

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -164,7 +164,7 @@ impl Inventory {
     }
 
     pub fn process_action(&mut self, action: &ItemOperation) {
-        if action.operation_type == 78 {
+        if action.operation_type == 145 {
             // discard
             let src_container = self.get_container_mut(&action.src_storage_id);
             let src_slot = src_container.get_slot_mut(action.src_container_index);

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -21,6 +21,8 @@ pub use storage::{ContainerType, Storage};
 mod currency;
 pub use currency::CurrencyStorage;
 
+use crate::INVENTORY_ACTION_DISCARD;
+
 const MAX_NORMAL_STORAGE: usize = 35;
 const MAX_LARGE_STORAGE: usize = 50;
 
@@ -164,8 +166,7 @@ impl Inventory {
     }
 
     pub fn process_action(&mut self, action: &ItemOperation) {
-        if action.operation_type == 145 {
-            // discard
+        if action.operation_type == INVENTORY_ACTION_DISCARD {
             let src_container = self.get_container_mut(&action.src_storage_id);
             let src_slot = src_container.get_slot_mut(action.src_container_index);
             *src_slot = Item::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,3 +78,9 @@ pub const COMPLETED_QUEST_BITMASK_SIZE: usize = 691;
 
 /// The operation opcode/type when discarding an item from the inventory.
 pub const INVENTORY_ACTION_DISCARD: u8 = 145;
+
+// The operation opcode/type when moving an item to an emtpy slot in the inventory.
+pub const INVENTORY_ACTION_MOVE: u8 = 146;
+
+// The operation opcode/type when moving an item to a slot occupied by another in the inventory.
+pub const INVENTORY_ACTION_EXCHANGE: u8 = 147;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,3 +75,6 @@ pub const AETHERYTE_UNLOCK_BITMASK_SIZE: usize = 30;
 
 /// The size of the completed quest bitmask.
 pub const COMPLETED_QUEST_BITMASK_SIZE: usize = 691;
+
+/// The operation opcode/type when discarding an item from the inventory.
+pub const INVENTORY_ACTION_DISCARD: u8 = 145;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,9 @@ pub const AETHERYTE_UNLOCK_BITMASK_SIZE: usize = 30;
 /// The size of the completed quest bitmask.
 pub const COMPLETED_QUEST_BITMASK_SIZE: usize = 691;
 
+/// The maximum durability of an item.
+pub const ITEM_CONDITION_MAX: u16 = 30000;
+
 /// The operation opcode/type when discarding an item from the inventory.
 pub const INVENTORY_ACTION_DISCARD: u8 = 145;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,8 @@ pub const COMPLETED_QUEST_BITMASK_SIZE: usize = 691;
 /// The operation opcode/type when discarding an item from the inventory.
 pub const INVENTORY_ACTION_DISCARD: u8 = 145;
 
-// The operation opcode/type when moving an item to an emtpy slot in the inventory.
+/// The operation opcode/type when moving an item to an emtpy slot in the inventory.
 pub const INVENTORY_ACTION_MOVE: u8 = 146;
 
-// The operation opcode/type when moving an item to a slot occupied by another in the inventory.
+/// The operation opcode/type when moving an item to a slot occupied by another in the inventory.
 pub const INVENTORY_ACTION_EXCHANGE: u8 = 147;

--- a/src/world/chat_handler.rs
+++ b/src/world/chat_handler.rs
@@ -1,4 +1,5 @@
 use crate::{
+    ITEM_CONDITION_MAX,
     common::ItemInfoQuery,
     inventory::{Item, Storage},
     ipc::zone::{ChatMessage, GameMasterRank},
@@ -65,18 +66,11 @@ impl ChatHandler {
                             .get_equipslot_category(item_info.equip_category)
                             .unwrap();
 
-                        connection
-                            .player_data
-                            .inventory
-                            .equipped
-                            .get_slot_mut(slot)
-                            .id = item_info.id;
-                        connection
-                            .player_data
-                            .inventory
-                            .equipped
-                            .get_slot_mut(slot)
-                            .quantity = 1;
+                        let slot = connection.player_data.inventory.equipped.get_slot_mut(slot);
+
+                        slot.id = item_info.id;
+                        slot.quantity = 1;
+                        slot.condition = ITEM_CONDITION_MAX;
                     }
                 }
 


### PR DESCRIPTION
The equip command was not setting the durability of the item.