### PR TITLE
Attempt to improve the accuracy of a couple things

### DIFF
--- a/resources/opcodes.json
+++ b/resources/opcodes.json
@@ -239,6 +239,16 @@
             "name": "UnkResponse2",
             "opcode": 772,
             "size": 8
+        },
+        {
+            "name": "InventorySlotDiscard",
+            "opcode": 851,
+            "size": 48
+        },
+        {
+            "name": "InventorySlotDiscardFin",
+            "opcode": 854,
+            "size": 16
         }
     ],
     "ClientZoneIpcType": [

--- a/src/ipc/zone/actor_control.rs
+++ b/src/ipc/zone/actor_control.rs
@@ -109,6 +109,16 @@ pub enum ActorControlCategory {
         #[brw(pad_before = 2)] // padding
         emote: u32,
     },
+    #[brw(magic = 0x1ffu16)]
+    EventRelatedUnk1 {
+        #[brw(pad_before = 2)] // padding
+        unk1: u32,
+    },
+    #[brw(magic = 0x200u16)]
+    EventRelatedUnk2 {
+        #[brw(pad_before = 2)] // padding
+        unk1: u32,
+    },
     Unknown {
         category: u16,
         #[brw(pad_before = 2)] // padding

--- a/src/ipc/zone/mod.rs
+++ b/src/ipc/zone/mod.rs
@@ -92,6 +92,7 @@ use crate::common::ObjectTypeId;
 use crate::common::Position;
 use crate::common::read_string;
 use crate::common::write_string;
+use crate::inventory::ContainerType;
 use crate::opcodes::ClientZoneIpcType;
 use crate::opcodes::ServerZoneIpcType;
 use crate::packet::IPC_HEADER_SIZE;
@@ -346,6 +347,42 @@ pub enum ServerZoneIpcData {
     UnkResponse2 {
         #[brw(pad_after = 7)]
         unk1: u8,
+    },
+    #[br(pre_assert(*magic == ServerZoneIpcType::InventorySlotDiscard))]
+    InventorySlotDiscard {
+        /// This is later reused in InventorySlotDiscardFin, so it might be some sort of sequence or context id, but it's not the one sent by the client
+        unk1: u32,
+        /// Same as the one sent by the client, not the one that the server responds with in inventoryactionack!
+        operation_type: u8,
+        #[br(pad_before = 3)]
+        src_actor_id: u32,
+        src_storage_id: ContainerType,
+        src_container_index: u16,
+        #[br(pad_before = 2)]
+        src_stack: u32,
+        src_catalog_id: u32,
+
+        /// This is all static as far as I can tell, across two captures and a bunch of discards these never changed
+        /// seems to always be 3758096384 / E0 00 00 00
+        dst_actor_id: u32,
+        /// seems to always be 65535/0xFFFF
+        dst_storage_id: u16,
+        /// seems to always be 65535/0xFFFF
+        dst_container_index: u16,
+        /// seems to always be 0x0000FFFF
+        #[br(pad_after = 8)]
+        dst_catalog_id: u32,
+    },
+    #[br(pre_assert(*magic == ServerZoneIpcType::InventorySlotDiscardFin))]
+    InventorySlotDiscardFin {
+        /// Same value as unk1 in InventorySlotDiscard
+        unk1: u32,
+        /// Repeated unk1 value?
+        unk2: u32,
+        /// Unknown, seems to always be 0x00000090
+        unk3: u32,
+        /// Unknown, seems to always be 0x00000200
+        unk4: u32,
     },
     Unknown {
         #[br(count = size - 32)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,3 +87,11 @@ pub const INVENTORY_ACTION_MOVE: u8 = 146;
 
 /// The operation opcode/type when moving an item to a slot occupied by another in the inventory.
 pub const INVENTORY_ACTION_EXCHANGE: u8 = 147;
+
+/// The server's acknowledgement of a shop item being purchased.
+pub const INVENTORY_ACTION_ACK_SHOP: u8 = 6;
+
+/// The server's acknowledgement of the client modifying their inventory.
+/// In the past, many more values were used according to Sapphire:
+/// https://github.com/SapphireServer/Sapphire/blob/044bff026c01b4cc3a37cbc9b0881fadca3fc477/src/common/Common.h#L83
+pub const INVENTORY_ACTION_ACK_GENERAL: u8 = 7;

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -323,6 +323,29 @@ pub async fn server_main_loop(mut recv: Receiver<ToServer>) -> Result<(), std::i
                                 to_remove.push(id);
                             }
                         }
+
+                        if let ClientTriggerCommand::EventRelatedUnk {
+                            unk1: _,
+                            unk2: _,
+                            unk3: _,
+                            unk4: _,
+                        } = &trigger.trigger
+                        {
+                            let msg = FromServer::ActorControlSelf(ActorControlSelf {
+                                category: ActorControlCategory::EventRelatedUnk1 { unk1: 1 },
+                            });
+
+                            if handle.send(msg).is_err() {
+                                to_remove.push(id);
+                            }
+                            let msg = FromServer::ActorControlSelf(ActorControlSelf {
+                                category: ActorControlCategory::EventRelatedUnk2 { unk1: 0 },
+                            });
+
+                            if handle.send(msg).is_err() {
+                                to_remove.push(id);
+                            }
+                        }
                         continue;
                     }
 


### PR DESCRIPTION
-ItemOperation: Now sends back ItemAcknowledgeAck as well as InventorySlotDiscard and *Fin when discarding items 
-ClientTrigger::EventRelatedUnk: send back commonly observed ActorControlSelf responses