### PR TITLE
Fix a couple issues with the Unending Journey

### DIFF
--- a/resources/scripts/events/tosort/UnendingJourney.lua
+++ b/resources/scripts/events/tosort/UnendingJourney.lua
@@ -5,17 +5,21 @@ SCENE_SHOW_MENU       = 00000
 SCENE_PLAY_CUTSCENE   = 00001
 
 function onTalk(target, player)
-    -- you cannot consult, which is good because we don't know how to implement this anyway
     player:play_scene(target, EVENT_ID, SCENE_SHOW_MENU, 8192, {0})
 end
 
 function onReturn(scene, results, player)
-    -- A result of zero means the user exited the menu without playing anything.
-    if scene == 0 and results[1] ~= 0 then
+    local NO_SCENE <const> = 0
+    local decision <const> = results[1]
+
+    if scene == SCENE_SHOW_MENU and decision ~= NO_SCENE then
         -- TODO: we need to switch the player into viewingcutscene online status (on the Rust side?)
         player:play_scene(player.id, EVENT_ID, SCENE_PLAY_CUTSCENE, SET_BASE, results)
-        return
-        -- TODO: we cannot nest cutscenes right now, but control should return back to the UEJ menu when a cutscene finishes
+    elseif scene == SCENE_PLAY_CUTSCENE then
+        --[[ TODO: How can we make it fade back in smoothly after the cutscene finishes?
+            Could it be related to ActorControl(ViewingCutscene)? ]]
+        player:play_scene(player.id, EVENT_ID, SCENE_SHOW_MENU, 8192, {1})
+    else
+        player:finish_event(EVENT_ID)
     end
-    player:finish_event(EVENT_ID)
 end

--- a/resources/scripts/events/tosort/UnendingJourney.lua
+++ b/resources/scripts/events/tosort/UnendingJourney.lua
@@ -1,3 +1,6 @@
+-- Cutscene flags, TODO: move these to Global.lua, or maybe a new file named Cutscene.lua or something along those lines, to store all of them
+SET_BASE = 0xF8400EFB -- Pulled from Sapphire, perhaps the default flags the server sends for most cutscenes?
+
 SCENE_SHOW_MENU       = 00000
 SCENE_PLAY_CUTSCENE   = 00001
 
@@ -7,11 +10,12 @@ function onTalk(target, player)
 end
 
 function onReturn(scene, results, player)
-    if scene == 0 then
-        -- TODO: this is not the correct cutscene flags
-        -- TODO: we need to switch the player into viewingcutscene online status
-        player:play_scene(player.id, EVENT_ID, SCENE_PLAY_CUTSCENE, 8192, results)
+    -- A result of zero means the user exited the menu without playing anything.
+    if scene == 0 and results[1] ~= 0 then
+        -- TODO: we need to switch the player into viewingcutscene online status (on the Rust side?)
+        player:play_scene(player.id, EVENT_ID, SCENE_PLAY_CUTSCENE, SET_BASE, results)
         return
+        -- TODO: we cannot nest cutscenes right now, but control should return back to the UEJ menu when a cutscene finishes
     end
     player:finish_event(EVENT_ID)
 end


### PR DESCRIPTION
-Fade to black smoothly so the transition into a cutscene isn't so jarring
-Don't softlock when exiting the menu without playing anything
-Return control to the UEJ menu after a cutscene finishes (but fading in from black is still not implemented, it might be related to ActorControl (ViewingCutscene))?