### PR TITLE
Enable a number of ferry skippers and other generic warps around several areas

### DIFF
--- a/resources/scripts/events/Events.lua
+++ b/resources/scripts/events/Events.lua
@@ -44,6 +44,7 @@ generic_warps = {
     131169,  -- Ferry Skipper from Eastern La Noscea: Costa Del Sol to ELN: Rhotano Privateer
     131177,  -- Exit from The Gold Saucer (Lift Operator) to The Gold Saucer: Chocobo Square
     131178,  -- Exit from The Gold Saucer: Chocobo Square (Lift Operator) to The Gold Saucer
+    131192,  -- House Fortemps Guard <Gatekeep> From Ishgard: The Pillars to Fortemps Manor
     131195,  -- Exit from Fortemps manor to Ishgard: The Pillars
     131204,  -- Exit Ishgard: Foundation to Cloud Nine Inn room
     131205,  -- Exit Cloud Nine to Ishgard: Foundation

--- a/resources/scripts/events/Events.lua
+++ b/resources/scripts/events/Events.lua
@@ -10,12 +10,20 @@ generic_warps = {
     131082,  -- Exit Mizzenmast Inn to Limsa Upper Decks
     131083,  -- Exit The Roost to New Gridania
     131084,  -- Exit The Hourglass to Ul'dah: Steps of Nald
+    131086,  -- Ferry Skipper from Western Thanalan: The Silver Bazaar to Western Thanalan: Cescent Cove
+    131087,  -- Ferry Skipper from Western Thanalan: Crescent Cove to Western Thanalan: The Silver Bazaar
+    131088,  -- Exit from Western Thanalan: Vesper Bay to The Waking Sands
+    131089,  -- Exit from The Waking Sands to Western Thanalan: Vesper Bay
+    131090,  -- Exit from The Waking Sands to The Solar
+    131091,  -- Exit from The Solar to The Waking Sands
     131092,  -- Exit from Limsa Bulwark Hall and/or Drowning Wench to Airship Landing
     131093,  -- Exit from Limsa Bullwark Hall and/or Airship Landing to Drowning Wench
     131094,  -- Exit from Limsa Airship Landing and/or Drowning Wench to Bulwark Hall
     131095,  -- Exit from Ul'dah Hustings Strip and/or Ruby Road Exchange to Airship Landing, these three events get reused in several places to ensure they all connect
     131096,  -- Exit from Ul'dah Airship Landing and/or Ruby Road Exchange to Hustings Strip
     131097,  -- Exit from Ul'dah Airship Landing and/or Husting Strip to Ruby Road Exchange
+    131107,  -- Nunuri <Ferry Ticketer> from Western Thanalan: Vesper Bay to Limsa Lominsa: The Lower Decks
+    131108,  -- Rhetkympf <Ferry Ticketer> from Limsa Lominsa: The Lower Decks to Western Thanalan: Vesper Bay
     131109,  -- Rerenasu <Ferry Skipper> from Limsa Lominsa: The Lower Decks to Western La Noscea: Aleport
     131110,  -- Ferry Skipper from Western La Noscea: Aleport to Limsa Lominsa: The Lower Decks
     131111,  -- Rerenasu <Ferry Skipper> from Limsa Lominsa: The Lower Decks to Eastern La Noscea: Costa Del Sol
@@ -41,8 +49,11 @@ generic_warps = {
     131205,  -- Exit Cloud Nine to Ishgard: Foundation
     131245,  -- Exit Kugane to Bokairo Inn room
     131246,  -- Exit Bokairo Inn to Kugane
+    -- 131248,  -- Kimachi <Ferry Skipper> from Kugane to Shirogane, needs special handling for housing
     131250,  -- Gatekeeper from The Fringes: Castrum Oriens to East Shroud: Amarissaaix's Spire
     131251,  -- Gatekeeper from East Shroud: Amarissaaix's Spire to The Fringes: Castrum Oriens
+    131252,  -- Uguisu <Ferry Skipper> from Kugane to Limsa Lominsa: The Lower Decks
+    131253,  -- East Aldenard Trading Company Sailor from Limsa Lominsa: The Lower Decks to Kugane
     131255,  -- Ala Mhigan Resistance Gate Guard from The Fringes: Virdjala to The Fringes: Pike Falls
     131266,  -- Gatekeeper from The House of the Fierce to dead-end cave (unable to dive currently)
     131268,  -- Enclave Skiff Captain from The Doman Enclave to Yanxia: The Glittering Basin
@@ -51,6 +62,8 @@ generic_warps = {
     131313,  -- Exit from The Crown Lift (Lift Operator) to Eulmore: The Canopy
     131390,  -- Exit via Pawlin <Dreamer's Run Doorman> from Old Gridania: Dreamer's Run (old Hatchingtide event area which is now out of bounds) to Old Gridania: Botanists' Guild
     131402,  -- Exit Andron to Old Sharlayan
+    131405,  -- Aergwynt <Ferry Ticketer> from Old Sharlayan to Limsa Lominsa: The Lower Decks
+    131406,  -- Sailor <Ferryman> from Limsa Lominsa: The Lower Decks to Old Sharlayan
     131428,  -- Exit from The Mothercrystal to Labyrinthos: The Aitiascope (outside, on overworld): probably supposed to drop you into a cutscene zone instead.
     131519,  -- Faire Adventurer from Eastern La Noscea: bottom of the Moonfire Festival (2023 tower to the first tier of the tower
     131578,  -- Exit The For'ard Cabins to Tuliyollal

--- a/resources/scripts/events/Events.lua
+++ b/resources/scripts/events/Events.lua
@@ -66,6 +66,7 @@ generic_warps = {
     131406,  -- Sailor <Ferryman> from Limsa Lominsa: The Lower Decks to Old Sharlayan
     131428,  -- Exit from The Mothercrystal to Labyrinthos: The Aitiascope (outside, on overworld): probably supposed to drop you into a cutscene zone instead.
     131519,  -- Faire Adventurer from Eastern La Noscea: bottom of the Moonfire Festival (2023 tower to the first tier of the tower
+    131545,  -- Port Official from Tuliyollal to Old Sharlayan
     131578,  -- Exit The For'ard Cabins to Tuliyollal
 }
 

--- a/resources/scripts/events/Events.lua
+++ b/resources/scripts/events/Events.lua
@@ -16,16 +16,21 @@ generic_warps = {
     131095,  -- Exit from Ul'dah Hustings Strip and/or Ruby Road Exchange to Airship Landing, these three events get reused in several places to ensure they all connect
     131096,  -- Exit from Ul'dah Airship Landing and/or Ruby Road Exchange to Hustings Strip
     131097,  -- Exit from Ul'dah Airship Landing and/or Husting Strip to Ruby Road Exchange
-    -- 131109, -- Rerenasu <Ferry Skipper> from Limsa Lominsa: The Lower Decks to Western La Noscea: Aleport, currently doesn't respond because we currently can't chain differing cutscene ids yet?
-    -- 131111, -- Rerenasu <Ferry Skipper> from Limsa Lominsa: The Lower Decks to Eastern La Noscea: Costa Del Sol, currently doesn't respond because we currently can't chain differing cutscene ids yet?
-    -- 131112, -- Ferry Skipper from Eastern La Noscea: Costa Del Sol to Limsa Lominsa: The Lower Decks, currently doesn't respond because we currently can't chain differing cutscene ids yet?
+    131109,  -- Rerenasu <Ferry Skipper> from Limsa Lominsa: The Lower Decks to Western La Noscea: Aleport
+    131110,  -- Ferry Skipper from Western La Noscea: Aleport to Limsa Lominsa: The Lower Decks
+    131111,  -- Rerenasu <Ferry Skipper> from Limsa Lominsa: The Lower Decks to Eastern La Noscea: Costa Del Sol
+    131112,  -- Ferry Skipper from Eastern La Noscea: Costa Del Sol to Limsa Lominsa: The Lower Decks
     131113,  -- Ferry Skipper from Upper La Noscea: Memeroon's Trading Post to Upper La Noscea: Jijiroon's Trading Post
     131114,  -- Ferry Skipper from Upper La Noscea: Jijiroon's Trading Post to Upper La Noscea: Memeroon's Trading Post
+    131115,  -- O'nolosi <Ferry Skipper> from Lower La Noscea: Candlekeep Quay to Western La Noscea: Aleport
+    131116,  -- Ferry Skipper from Western La Noscea: Aleport to Lower La Noscea: Candlekeep Quay
     131119,  -- Ferry Skipper from Eastern La Noscea: Hidden Falls Docks to Eastern La Noscea: Raincatcher Gully Docks
     131120,  -- Ferry Skipper from Eastern La Noscea: Raincatcher Gully Docks to Eastern La Noscea: Hidden Falls Docks
     131126,  -- Gatekeeper from Southern Thanalan: Nald's Reflection to Southern Thanalan: The Minotaur Malm
     131131,  -- Ferry Skipper from Moraby Drydocks to Wolves' Den Pier
     131132,  -- Ferry Skipper from Wolves' Den Pier to Moraby Drydocks
+    131133,  -- Ferry Skipper from Western La Noscea: The Isles of Umbra to Western La Noscea: Aleport
+    131134,  -- Ferry Skipper from Western La Noscea: Aleport to Western La Noscea: The Isles of Umbra
     -- 131158, None -- Ferry Skipper from Old Gridania to The Lavender Beds, needs special handling for housing
     -- 131160, None -- Rerenasu <Ferry Skipper> from Limsa Lominsa: The Lower Decks to Mist, needs special handling for housing
     131169,  -- Ferry Skipper from Eastern La Noscea: Costa Del Sol to ELN: Rhotano Privateer


### PR DESCRIPTION
Several of these weren't working recently, but now they do (some require level and/or quest completion though, so if they don't respond, up your level and complete quests!), so there's no harm letting them help the player out with moving around.