### PR TITLE
Update the Unending Journey's cutscene replay scene flags one more time

### DIFF
--- a/resources/scripts/events/tosort/UnendingJourney.lua
+++ b/resources/scripts/events/tosort/UnendingJourney.lua
@@ -1,5 +1,8 @@
 -- Cutscene flags, TODO: move these to Global.lua, or maybe a new file named Cutscene.lua or something along those lines, to store all of them
-SET_BASE = 0xF8400EFB -- Pulled from Sapphire, perhaps the default flags the server sends for most cutscenes?
+--[[ Captured from retail, this allows smooth fading in and out on both sides of the cutscene, and it would be a good idea
+to see what flags are set that make it different than SET_BASE, but for now this makes the Unending Journey as accurate
+as it possibly can be on our end. ]]
+UEJ_REPLAY_FLAGS = 0xf8c82efb
 
 SCENE_SHOW_MENU       = 00000
 SCENE_PLAY_CUTSCENE   = 00001
@@ -14,10 +17,8 @@ function onReturn(scene, results, player)
 
     if scene == SCENE_SHOW_MENU and decision ~= NO_SCENE then
         -- TODO: we need to switch the player into viewingcutscene online status (on the Rust side?)
-        player:play_scene(player.id, EVENT_ID, SCENE_PLAY_CUTSCENE, SET_BASE, results)
+        player:play_scene(player.id, EVENT_ID, SCENE_PLAY_CUTSCENE, UEJ_REPLAY_FLAGS, results)
     elseif scene == SCENE_PLAY_CUTSCENE then
-        --[[ TODO: How can we make it fade back in smoothly after the cutscene finishes?
-            Could it be related to ActorControl(ViewingCutscene)? ]]
         player:play_scene(player.id, EVENT_ID, SCENE_SHOW_MENU, 8192, {1})
     else
         player:finish_event(EVENT_ID)


### PR DESCRIPTION
-This is what retail sends, and it has smooth fade ins and outs on upon start and end of cutscenes.