### PR TITLE
Rename inventory-related opcodes to match Karashiiro/FFXIVOpcodes

### DIFF
--- a/resources/opcodes.json
+++ b/resources/opcodes.json
@@ -241,12 +241,12 @@
             "size": 8
         },
         {
-            "name": "InventorySlotDiscard",
+            "name": "InventoryTransaction",
             "opcode": 851,
             "size": 48
         },
         {
-            "name": "InventorySlotDiscardFin",
+            "name": "InventoryTransactionFinish",
             "opcode": 854,
             "size": 16
         }
@@ -395,6 +395,11 @@
         {
             "name": "UnkCall2",
             "opcode": 632,
+            "size": 8
+        },
+        {
+            "name": "StandardControlsPivot",
+            "opcode": 836,
             "size": 8
         }
     ],

--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -815,9 +815,9 @@ async fn client_loop(
                                                     tracing::info!("Player is discarding from their inventory!");
                                                     let sequence = 0; // TODO: How is this decided? It seems to be a sequence value but it's not sent by the client! Perhaps it's a 'lifetime-of-the-character' value that simply gets increased for every inventory action ever taken?
                                                     let ipc = ServerZoneIpcSegment {
-                                                        op_code: ServerZoneIpcType::InventorySlotDiscard,
+                                                        op_code: ServerZoneIpcType::InventoryTransaction,
                                                         timestamp: timestamp_secs(),
-                                                        data: ServerZoneIpcData::InventorySlotDiscard {
+                                                        data: ServerZoneIpcData::InventoryTransaction {
                                                             unk1: sequence,
                                                             operation_type: action.operation_type,
                                                             src_actor_id: action.src_actor_id,
@@ -843,9 +843,9 @@ async fn client_loop(
                                                     .await;
 
                                                     let ipc = ServerZoneIpcSegment {
-                                                        op_code: ServerZoneIpcType::InventorySlotDiscard,
+                                                        op_code: ServerZoneIpcType::InventoryTransactionFinish,
                                                         timestamp: timestamp_secs(),
-                                                        data: ServerZoneIpcData::InventorySlotDiscardFin {
+                                                        data: ServerZoneIpcData::InventoryTransactionFinish {
                                                             unk1: sequence,
                                                             unk2: sequence, // yes, this repeats, it's not a copy paste error
                                                             unk3: 0x90,
@@ -989,6 +989,10 @@ async fn client_loop(
                                                         config.clone(),
                                                     ))
                                                     .await;
+                                            }
+                                            ClientZoneIpcData::StandardControlsPivot { .. } => {
+                                                /* No-op because we already seem to handle this, other nearby clients can see the sending player
+                                                 * pivoting anyway. */
                                             }
                                             ClientZoneIpcData::EventUnkRequest { event_id, unk1, unk2, unk3 } => {
                                                  let ipc = ServerZoneIpcSegment {

--- a/src/ipc/zone/mod.rs
+++ b/src/ipc/zone/mod.rs
@@ -380,8 +380,8 @@ pub enum ServerZoneIpcData {
         #[brw(pad_after = 7)]
         unk1: u8,
     },
-    #[br(pre_assert(*magic == ServerZoneIpcType::InventorySlotDiscard))]
-    InventorySlotDiscard {
+    #[br(pre_assert(*magic == ServerZoneIpcType::InventoryTransaction))]
+    InventoryTransaction {
         /// This is later reused in InventorySlotDiscardFin, so it might be some sort of sequence or context id, but it's not the one sent by the client
         unk1: u32,
         /// Same as the one sent by the client, not the one that the server responds with in inventoryactionack!
@@ -405,8 +405,8 @@ pub enum ServerZoneIpcData {
         #[br(pad_after = 8)]
         dst_catalog_id: u32,
     },
-    #[br(pre_assert(*magic == ServerZoneIpcType::InventorySlotDiscardFin))]
-    InventorySlotDiscardFin {
+    #[br(pre_assert(*magic == ServerZoneIpcType::InventoryTransactionFinish))]
+    InventoryTransactionFinish {
         /// Same value as unk1 in InventorySlotDiscard
         unk1: u32,
         /// Repeated unk1 value?
@@ -564,6 +564,15 @@ pub enum ClientZoneIpcData {
         /// unk 2: Flags? These change quite a bit when dealing with stackable items, but are apparently always 0 when buying non-stackable
         /// Observed values so far: 0xDDDDDDDD (when buying 99 of a stackable item), 0xFFFFFFFF, 0xFFE0FFD0, 0xfffefffe, 0x0000FF64
         unk2: u32,
+    },
+    /// This packet is sent by the client when they pivot left or right on standard controls.
+    /// It is sent once when beginning to pivot, and once when pivoting ends.
+    #[br(pre_assert(*magic == ClientZoneIpcType::StandardControlsPivot))]
+    StandardControlsPivot {
+        /// Set to 4 when beginning to pivot.
+        /// Set to 0 when pivoting ends.
+        #[brw(pad_after = 4)]
+        is_pivoting: u32,
     },
     #[br(pre_assert(*magic == ClientZoneIpcType::EventYieldHandler))]
     EventYieldHandler(EventYieldHandler<2>),


### PR DESCRIPTION
-Renamed inventory-related opcodes (that I implemented) to match Karashiiro/FFXIVOpcodes, I didn't know at the time they had record of them!
-Implement keyboard turning packet as a no-op so it'll stop clogging server logs