### PR TITLE
Re-add support for adding items to slots other than the first

### DIFF
--- a/resources/scripts/events/Events.lua
+++ b/resources/scripts/events/Events.lua
@@ -333,6 +333,8 @@ common_events = {
 generic_gil_shops = {
     262157, -- Tanie <Florist>, New Gridania
     262197, -- Gerulf <Independent Culinarian>, Limsa Lominsa: The Lower Decks
+    262735, -- Sorcha <Independent Jeweler> (Limsa Lominsa: The Lower Decks), Battlecraft Accessories
+    262736, -- Sorcha <Independent Jeweler> (Limsa Lominsa: The Lower Decks), Fieldcraft/Tradecraft Accessories
     263220, -- Neon <Air-wheeler dealer>, Solution Nine
 }
 

--- a/src/common/gamedata.rs
+++ b/src/common/gamedata.rs
@@ -49,7 +49,10 @@ pub struct ItemInfo {
     pub price_low: u32,
     /// The item's equip category.
     pub equip_category: u8,
+    /// The item's primary model id.
     pub primary_model_id: u64,
+    /// The item's max stack size.
+    pub stack_size: u32,
 }
 
 #[derive(Debug)]
@@ -191,6 +194,10 @@ impl GameData {
                 panic!("Unexpected type!");
             };
 
+            let physis::exd::ColumnData::UInt32(stack_size) = &matched_row.columns[20] else {
+                panic!("Unexpected type!");
+            };
+
             let physis::exd::ColumnData::UInt32(price_mid) = &matched_row.columns[25] else {
                 panic!("Unexpected type!");
             };
@@ -210,6 +217,7 @@ impl GameData {
                 price_low: *price_low,
                 equip_category: *equip_category,
                 primary_model_id: *primary_model_id,
+                stack_size: *stack_size,
             };
 
             return Some(item_info);

--- a/src/inventory/generic.rs
+++ b/src/inventory/generic.rs
@@ -1,3 +1,4 @@
+use crate::inventory::ContainerType;
 use serde::{Deserialize, Serialize};
 
 use super::{Item, Storage};
@@ -5,12 +6,15 @@ use super::{Item, Storage};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GenericStorage<const N: usize> {
     pub slots: Vec<Item>,
+    #[serde(skip)]
+    pub kind: ContainerType,
 }
 
 impl<const N: usize> Default for GenericStorage<N> {
     fn default() -> Self {
         Self {
             slots: vec![Item::default(); N],
+            kind: ContainerType::Invalid,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,3 +115,7 @@ pub const INVENTORY_ACTION_ACK_SHOP: u8 = 6;
 /// In the past, many more values were used according to Sapphire:
 /// https://github.com/SapphireServer/Sapphire/blob/044bff026c01b4cc3a37cbc9b0881fadca3fc477/src/common/Common.h#L83
 pub const INVENTORY_ACTION_ACK_GENERAL: u8 = 7;
+
+/// Error messages: TODO: this should probably be moved into its own universal mod/crate?
+pub const ERR_INVENTORY_ADD_FAILED: &str =
+    "Unable to add item to inventory! Your inventory is full, or this is a bug in Kawari!";

--- a/src/world/chat_handler.rs
+++ b/src/world/chat_handler.rs
@@ -96,12 +96,12 @@ impl ChatHandler {
 
                 if result.is_some() {
                     connection.send_inventory(false).await;
-                    true
                 } else {
                     tracing::error!(ERR_INVENTORY_ADD_FAILED);
                     connection.send_message(ERR_INVENTORY_ADD_FAILED).await;
-                    true
                 }
+
+                true
             }
             "!reload" => {
                 connection.reload_scripts();


### PR DESCRIPTION
-Adding items to the inventory via any means will now find an appropriate stack to add onto, or failing that, create a new stack when possible, while unstackable items will go straight to finding a new open slot. If we're unable to find an open slot for some reason, an error is returned (or more precisely, the caller will have to deal with the Option being None, indicating an error.

-Adding an item to the inventory will return an `Option<ItemDestinationInfo>`, which is a simple type that allows the caller to determine what storage the item was added into, the index into the storage, and how many items are now at that location.

-GenericStorage instances will now be able to specify the kind of inventory that they represent, making it simple to find out (which is required when adding items to the inventory for gil shops, etc). For the moment, only the 4 main inventories specify this, and the rest declare themselves as invalid by default (this has no functional difference for operating on items in those other inventories, like the armoury chest categories).