### PR TITLE
Implement basic support for item levels and start working on migrating to using Item instead of BuyBackItem

### DIFF
--- a/src/common/gamedata.rs
+++ b/src/common/gamedata.rs
@@ -37,7 +37,7 @@ impl Default for GameData {
 }
 
 /// Struct detailing various information about an item, pulled from the Items sheet.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ItemInfo {
     /// The item's textual name.
     pub name: String,
@@ -53,6 +53,8 @@ pub struct ItemInfo {
     pub primary_model_id: u64,
     /// The item's max stack size.
     pub stack_size: u32,
+    /// The item's item level.
+    pub item_level: u16,
 }
 
 #[derive(Debug)]
@@ -190,6 +192,10 @@ impl GameData {
                 panic!("Unexpected type!");
             };
 
+            let physis::exd::ColumnData::UInt16(item_level) = &matched_row.columns[11] else {
+                panic!("Unexpected type!");
+            };
+
             let physis::exd::ColumnData::UInt8(equip_category) = &matched_row.columns[17] else {
                 panic!("Unexpected type!");
             };
@@ -218,6 +224,7 @@ impl GameData {
                 equip_category: *equip_category,
                 primary_model_id: *primary_model_id,
                 stack_size: *stack_size,
+                item_level: *item_level,
             };
 
             return Some(item_info);

--- a/src/inventory/buyback.rs
+++ b/src/inventory/buyback.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, VecDeque};
 const BUYBACK_LIST_SIZE: usize = 10;
 const BUYBACK_PARAM_COUNT: usize = 22;
 
+// TODO: Deprecate this type, Item can now be expanded to support everything we'll need
 #[derive(Clone, Debug, Default)]
 pub struct BuyBackItem {
     pub id: u32,
@@ -11,6 +12,7 @@ pub struct BuyBackItem {
     // TODO: there are 22 total things the server keeps track of and sends back to the client, we should implement these!
     // Not every value is not fully understood but they appeared to be related to item quality, materia melds, the crafter's name (if applicable), spiritbond/durability, and maybe more.
     /// Fields beyond this comment are not part of the 22 datapoints the server sends to the client, but we need them for later item restoration.
+    pub item_level: u16,
     pub stack_size: u32,
 }
 
@@ -74,5 +76,18 @@ impl BuyBackList {
         }
 
         params
+    }
+}
+
+// TODO: Once BBItem is deprecated, remove this. This is a transitional impl as we migrate to using Item.
+impl BuyBackItem {
+    pub fn as_item_info(&self) -> crate::common::ItemInfo {
+        crate::common::ItemInfo {
+            id: self.id,
+            item_level: self.item_level,
+            stack_size: self.stack_size,
+            price_low: self.price_low,
+            ..Default::default()
+        }
     }
 }

--- a/src/inventory/currency.rs
+++ b/src/inventory/currency.rs
@@ -1,3 +1,5 @@
+use crate::common::ItemInfo;
+
 use serde::{Deserialize, Serialize};
 
 use super::{Item, Storage};
@@ -39,6 +41,17 @@ pub enum CurrencyKind {
     TrophyCrystal = 36656,
 }
 
+// TODO: Should we just pull this from the Item sheet?
+// Otherwise, should we not use Default and instead use new with a GameData parameter?
+pub enum CurrencyStack {
+    _CompanySeal = 90000,
+    _ElementalCrystal = 9999,
+    Gil = 999_999_999,
+    _MGP = 9_999_999,
+    _Tomestone = 2000,
+    _Pvp = 20000,
+}
+
 #[derive(Clone, Copy, Deserialize, Serialize, Debug)]
 pub struct CurrencyStorage {
     pub gil: Item,
@@ -47,7 +60,14 @@ pub struct CurrencyStorage {
 impl Default for CurrencyStorage {
     fn default() -> Self {
         Self {
-            gil: Item::new(0, CurrencyKind::Gil as u32),
+            gil: Item::new(
+                ItemInfo {
+                    id: CurrencyKind::Gil as u32,
+                    stack_size: CurrencyStack::Gil as u32,
+                    ..Default::default()
+                },
+                0,
+            ),
         }
     }
 }

--- a/src/inventory/item.rs
+++ b/src/inventory/item.rs
@@ -1,21 +1,32 @@
+use crate::common::ItemInfo;
+
 use crate::ITEM_CONDITION_MAX;
 use serde::{Deserialize, Serialize};
 
-/// Represents an item, or if the quanity is zero an empty slot.
+/// Represents an item, or if the quantity is zero, an empty slot.
 #[derive(Default, Copy, Clone, Serialize, Deserialize, Debug)]
 pub struct Item {
     pub quantity: u32,
     pub id: u32,
     pub condition: u16,
     pub glamour_catalog_id: u32,
+    #[serde(skip)]
+    pub item_level: u16,
+    #[serde(skip)]
+    pub stack_size: u32,
+    #[serde(skip)]
+    pub price_low: u32,
 }
 
 impl Item {
-    pub fn new(quantity: u32, id: u32) -> Self {
+    pub fn new(item_info: ItemInfo, quantity: u32) -> Self {
         Self {
             quantity,
-            id,
+            id: item_info.id,
             condition: ITEM_CONDITION_MAX,
+            item_level: item_info.item_level,
+            stack_size: item_info.stack_size,
+            price_low: item_info.price_low,
             ..Default::default()
         }
     }
@@ -26,5 +37,9 @@ impl Item {
             return self.glamour_catalog_id;
         }
         self.id
+    }
+
+    pub fn is_empty_slot(&self) -> bool {
+        self.quantity == 0
     }
 }

--- a/src/world/chat_handler.rs
+++ b/src/world/chat_handler.rs
@@ -87,10 +87,10 @@ impl ChatHandler {
                     if let Some(item_info) =
                         gamedata.get_item_info(ItemInfoQuery::ByName(name.to_string()))
                     {
-                        result = connection.player_data.inventory.add_in_next_free_slot(
-                            Item::new(1, item_info.id),
-                            item_info.stack_size,
-                        );
+                        result = connection
+                            .player_data
+                            .inventory
+                            .add_in_next_free_slot(Item::new(item_info, 1));
                     }
                 }
 

--- a/src/world/connection.rs
+++ b/src/world/connection.rs
@@ -478,6 +478,13 @@ impl ZoneConnection {
             })
             .await;
         }
+
+        self.actor_control_self(ActorControlSelf {
+            category: ActorControlCategory::SetItemLevel {
+                level: self.player_data.inventory.equipped.calculate_item_level() as u32,
+            },
+        })
+        .await;
     }
 
     pub async fn warp(&mut self, warp_id: u32) {
@@ -929,10 +936,7 @@ impl ZoneConnection {
                         if self
                             .player_data
                             .inventory
-                            .add_in_next_free_slot(
-                                Item::new(*quantity, *id),
-                                item_info.unwrap().stack_size,
-                            )
+                            .add_in_next_free_slot(Item::new(item_info.unwrap(), *quantity))
                             .is_some()
                         {
                             if *send_client_update {

--- a/src/world/lua.rs
+++ b/src/world/lua.rs
@@ -365,11 +365,11 @@ impl LuaPlayer {
 
         // This is a no-op since we can't edit PlayerData from the Lua side, but we can queue it up afterward.
         // We *need* this information, though.
-        let item_to_restore = Item::new(bb_item.quantity, bb_item.id);
+        let item_to_restore = Item::new(bb_item.as_item_info(), bb_item.quantity);
         let Some(item_dst_info) = self
             .player_data
             .inventory
-            .add_in_next_free_slot(item_to_restore, bb_item.stack_size)
+            .add_in_next_free_slot(item_to_restore)
         else {
             let error = "Your inventory is full. Unable to restore item.";
             self.send_message(error, 0);


### PR DESCRIPTION
-This is a very early implementation of it.
-It doesn't take into account 1h vs 2h situations (i.e. on retail, PLD, WHM/BLM with wand, and DoH/DoL are calculated slightly differently).
-It doesn't take into account multi-slot armour.
-When you equip or unequip items, your item level will now update as expected. 
-The equip debug command does not currently update the item level.
-Item will eventually hold most fields from the Item excel sheet, so BuyBackItem is effectively deprecated.