### PR TITLE
Fix size of InitResponse opcode

### DIFF
--- a/resources/opcodes.json
+++ b/resources/opcodes.json
@@ -33,7 +33,7 @@
         {
             "name": "InitResponse",
             "opcode": 186,
-            "size": 16
+            "size": 14
         },
         {
             "name": "LogOutComplete",

--- a/src/ipc/zone/mod.rs
+++ b/src/ipc/zone/mod.rs
@@ -190,7 +190,7 @@ pub enum ServerZoneIpcData {
     InitResponse {
         unk1: u64,
         character_id: u32,
-        unk2: u32,
+        unk2: u16,
     },
     /// Sent by the server that tells the client which zone to load
     #[br(pre_assert(*magic == ServerZoneIpcType::InitZone))]


### PR DESCRIPTION
This opcode is currently showing up as unknown in PacketAnalyzer due to this.