### PR TITLE
Map out the client EquipGearset opcode (for Packet Analyzer)

### DIFF
--- a/resources/opcodes.json
+++ b/resources/opcodes.json
@@ -481,6 +481,11 @@
             "name": "ContentFinderAction",
             "opcode": 409,
             "size": 8
+        },
+        {
+            "name": "EquipGearset",
+            "opcode": 101,
+            "size": 72
         }
     ],
     "ServerLobbyIpcType": [

--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -1315,6 +1315,10 @@ async fn client_loop(
 
                                                 connection.queued_content = None;
                                             }
+                                            ClientZoneIpcData::EquipGearset { .. } => {
+                                                tracing::info!("Client tried to equip a gearset!");
+                                                connection.send_message("Gearsets are not yet implemented.").await;
+                                            }
                                             ClientZoneIpcData::Unknown { .. } => {
                                                 tracing::warn!("Unknown packet {:?} recieved, this should be handled!", data.op_code);
                                             }

--- a/src/ipc/zone/mod.rs
+++ b/src/ipc/zone/mod.rs
@@ -764,8 +764,9 @@ pub enum ClientZoneIpcData {
         /// Sapphire calls this a context id but it was observed as an actual index into the list of gearsets that the client keeps on its side.
         gearset_index: u32,
         /// In order: weapon, off-hand, head, body, hands, invalid/waist, legs, feet, earrings, neck, wrist, left ring, right ring, soul crystal
+        /// When a container is irrelevant, it is marked as 9999/ContainerType::Invalid.
         containers: [ContainerType; 14],
-        /// Indices into the storages.
+        /// Indices into the containers.
         indices: [u16; 14],
         /// For the moment, it is completely unclear what unk1 and unk2 are used for or represent.
         #[brw(pad_before = 6)]

--- a/src/ipc/zone/mod.rs
+++ b/src/ipc/zone/mod.rs
@@ -759,6 +759,20 @@ pub enum ClientZoneIpcData {
         #[brw(pad_after = 4)] // seems to empty
         content_ids: [u16; 5],
     },
+    #[br(pre_assert(*magic == ClientZoneIpcType::EquipGearset))]
+    EquipGearset {
+        /// Sapphire calls this a context id but it was observed as an actual index into the list of gearsets that the client keeps on its side.
+        gearset_index: u32,
+        /// In order: weapon, off-hand, head, body, hands, invalid/waist, legs, feet, earrings, neck, wrist, left ring, right ring, soul crystal
+        containers: [ContainerType; 14],
+        /// Indices into the storages.
+        indices: [u16; 14],
+        /// For the moment, it is completely unclear what unk1 and unk2 are used for or represent.
+        #[brw(pad_before = 6)]
+        unk1: u16,
+        #[brw(pad_after = 2)]
+        unk2: u16,
+    },
     #[br(pre_assert(*magic == ClientZoneIpcType::ContentFinderAction))]
     ContentFinderAction { unk1: [u8; 8] },
     Unknown {


### PR DESCRIPTION
This does not implement the opcode, it's more so Packet Analyzer can display the data cleanly.