### PR TITLE
Reorganize the client triggers by magic value order, and clean up some comments

### DIFF
--- a/src/ipc/zone/client/client_trigger.rs
+++ b/src/ipc/zone/client/client_trigger.rs
@@ -6,7 +6,7 @@ use crate::common::{DistanceRange, ObjectId, read_bool_from, write_bool_as};
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum ClientTriggerCommand {
     /// The player sheathes/unsheathes their weapon.
-    #[brw(magic = 0x1u16)]
+    #[brw(magic = 0x0001u16)]
     ToggleWeapon {
         #[brw(pad_before = 2)]
         #[br(map = read_bool_from::<u32>)]
@@ -14,73 +14,82 @@ pub enum ClientTriggerCommand {
         shown: bool,
     },
     /// The player looks or stops looking at an actor.
-    #[brw(magic = 0x3u16)]
+    #[brw(magic = 0x0003u16)]
     SetTarget {
         #[brw(pad_before = 2)]
         actor_id: u32,
     },
-    #[brw(magic = 0xC81u16)]
-    BeginLoading {},
-    #[brw(magic = 0xC9u16)]
-    FinishZoning {},
-    /// The player begins an emote.
-    #[brw(magic = 0x1F4u16)]
-    Emote {
-        #[brw(pad_before = 2)] // padding
-        emote: u32,
-    },
-    /// The player explicitly changed their pose.
-    #[brw(magic = 0x1F9u16)]
-    ChangePose {
-        #[brw(pad_before = 2)] // padding
-        unk1: u32,
-        pose: u32,
-    },
-    /// The client is "reapplying" the existing pose, like after idling.
-    #[brw(magic = 0x1FAu16)]
-    ReapplyPose {
-        #[brw(pad_before = 2)] // padding
-        unk1: u32,
-        pose: u32,
-    },
-    /// The player selects a teleport destination.
-    #[brw(magic = 0xCAu16)]
-    TeleportQuery {
-        #[brw(pad_before = 2)]
-        aetheryte_id: u32,
-        // TODO: fill out the rest
-    },
-    #[brw(magic = 0x25eu16)]
-    WalkInTriggerFinished {
-        #[brw(pad_before = 2)]
-        unk1: u32,
-    },
-    #[brw(magic = 0x033Eu16)]
-    EventRelatedUnk {
-        // seen in haircut event
-        #[brw(pad_before = 2)] // padding
-        unk1: u32,
-        unk2: u32,
-        unk3: u32,
-        unk4: u32,
-    },
-    #[brw(magic = 0x12Fu16)]
-    RequestTitleList {},
     /// When the player right-clicks their status effect to remove it.
-    #[brw(magic = 0x68u16)]
+    #[brw(magic = 0x0068u16)]
     ManuallyRemoveEffect {
         #[brw(pad_before = 2)] // padding
         effect_id: u32,
         unk1: u32,
         source_actor_id: ObjectId,
     },
+    /// The client is finished zoning.
+    #[brw(magic = 0x00C9u16)]
+    FinishZoning {},
+    /// The player selects a teleport destination.
+    #[brw(magic = 0x00CAu16)]
+    TeleportQuery {
+        #[brw(pad_before = 2)]
+        aetheryte_id: u32,
+        // TODO: fill out the rest
+    },
+    /// The client requests the player's unlocked titles.
+    #[brw(magic = 0x012Fu16)]
+    RequestTitleList {},
+    /// The player begins an emote.
+    #[brw(magic = 0x01F4u16)]
+    Emote {
+        #[brw(pad_before = 2)] // padding
+        emote: u32,
+    },
+    /// The player explicitly changed their pose.
+    #[brw(magic = 0x01F9u16)]
+    ChangePose {
+        #[brw(pad_before = 2)] // padding
+        unk1: u32,
+        pose: u32,
+    },
+    /// The client is "reapplying" the existing pose, like after idling.
+    #[brw(magic = 0x01FAu16)]
+    ReapplyPose {
+        #[brw(pad_before = 2)] // padding
+        unk1: u32,
+        pose: u32,
+    },
+    #[brw(magic = 0x025Eu16)]
+    WalkInTriggerFinished {
+        #[brw(pad_before = 2)]
+        unk1: u32,
+    },
     /// When the player begins swimming. Seems to have no parameters.
-    #[brw(magic = 0x260u16)]
+    #[brw(magic = 0x0260u16)]
     BeginSwimming {},
     /// When the player stops swimming (by going back on land, mounting, etc.). Seems to have no parameters.
-    #[brw(magic = 0x261u16)]
+    #[brw(magic = 0x0261u16)]
     EndSwimming {},
-    /// The client telling us how far in the distance we should see actors.
+    /// When the player enters an area where mounting is prohibited in a zone that otherwise permits zoning. Commonly seen during Moonfire Faire festivals, and does not seem to have an exit counterpart.
+    #[brw(magic = 0x0264u16)]
+    EnterMountingProhibitedArea {
+        #[brw(pad_before = 2)]
+        enabled: u32
+    },
+    /// Unknown purpose, but is seen during the crystal bell/aesthetician cutscenes.
+    #[brw(magic = 0x033Eu16)]
+    EventRelatedUnk {
+        #[brw(pad_before = 2)] // padding
+        unk1: u32,
+        unk2: u32,
+        unk3: u32,
+        unk4: u32,
+    },
+    /// The client is ready to begin loading a zone.
+    #[brw(magic = 0x0C81u16)]
+    BeginLoading {},
+    /// The client tells us how far in the distance we should see actors.
     #[brw(magic = 0x232Du16)]
     SetDistanceRange {
         #[brw(pad_before = 2)]

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -539,7 +539,7 @@ pub async fn server_main_loop(mut recv: Receiver<ToServer>) -> Result<(), std::i
                 for (id, (handle, _)) in &mut data.clients {
                     let id = *id;
 
-                    tracing::info!("{:#?}", trigger);
+                    tracing::info!("{:#X?}", trigger);
 
                     // handle player-to-server actions
                     if id == from_id {


### PR DESCRIPTION
Also introduce the trigger sent when the player enters an area where mounting is prohibited (e.g. Moonfire Faire areas).

The server will also display the printed ClientTrigger information in hex instead of decimal.