### PR TITLE
Document more chat opcodes, and fix the size of ActorControlTarget 

### DIFF
--- a/resources/data/opcodes.json
+++ b/resources/data/opcodes.json
@@ -56,7 +56,7 @@
         },
         {
             "name": "ServerChatMessage",
-            "comment": "Sent by the server when they send a chat message.",
+            "comment": "Sent by the server when they send a chat message. Usually used for login messages and imminent maintenance notices.",
             "opcode": 449,
             "size": 776
         },
@@ -231,7 +231,7 @@
             "name": "ActorControlTarget",
             "comment": "Used to control target information.",
             "opcode": 391,
-            "size": 28
+            "size": 32
         },
         {
             "name": "CurrencyCrystalInfo",
@@ -419,6 +419,12 @@
             "comment": "Sent to inform the client about server-local Linkshells, not to be confused with cross-world ones.",
             "opcode": 811,
             "size": 448
+        },
+        {
+            "name": "ChatMessage",
+            "comment": "Sent to nearby clients when a client sends a chat message in the say, yell, or shout channels.",
+            "opcode": 298,
+            "size": 1080
         }
     ],
     "ClientZoneIpcType": [
@@ -478,13 +484,13 @@
         },
         {
             "name": "Disconnected",
-            "comment": "Sent by the client when it's actually disconnecting",
+            "comment": "Sent by the client when it's actually disconnecting.",
             "opcode": 897,
             "size": 8
         },
         {
-            "name": "ChatMessage",
-            "comment": "Sent by the client when they send a chat message",
+            "name": "SendChatMessage",
+            "comment": "Sent by the client when they send a chat message.",
             "opcode": 563,
             "size": 1056
         },
@@ -729,7 +735,32 @@
             "comment": "Sent by the server to Initialize something chat-related?",
             "opcode": 2,
             "size": 8
+        },
+        {
+            "name": "TellMessage",
+            "comment": "Sent by the server in response to a client sending a private message to another client.",
+            "opcode": 100,
+            "size": 1080
+        },
+        {
+            "name": "PartyMessage",
+            "comment": "Sent by the server in response to a client sending a private message to another client.",
+            "opcode": 101,
+            "size": 1088
         }
     ],
-    "ClientChatIpcType": []
+    "ClientChatIpcType": [
+        {
+            "name": "SendTellMessage",
+            "comment": "Sent by the client when sending a private message to another client.",
+            "opcode": 100,
+            "size": 1080
+        },
+        {
+            "name": "SendPartyMessage",
+            "comment": "Sent by the client when sending a message to party chat.",
+            "opcode": 101,
+            "size": 1032
+        }
+    ]
 }

--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -462,7 +462,7 @@ async fn client_loop(
 
                                                 break;
                                             }
-                                            ClientZoneIpcData::ChatMessage(chat_message) => {
+                                            ClientZoneIpcData::SendChatMessage(chat_message) => {
                                                 connection.handle.send(ToServer::Message(connection.id, chat_message.message.clone())).await;
 
                                                 let mut handled = false;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -198,7 +198,8 @@ pub enum DistanceRange {
 #[brw(repr(u16))]
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub enum ChatChannel {
-    #[default] Say = 10,
+    #[default]
+    Say = 10,
     Shout = 11,
     Yell = 30,
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -193,6 +193,16 @@ pub enum DistanceRange {
     Maximum = 0x2,
 }
 
+// TODO: Possibly relocate this to src/world/common.rs as it's unclear if we'll need this in more places, so it was placed here for now.
+#[binrw]
+#[brw(repr(u16))]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub enum ChatChannel {
+    #[default] Say = 10,
+    Shout = 11,
+    Yell = 30,
+}
+
 #[binrw]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct EquipDisplayFlag(pub u16);

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -196,7 +196,7 @@ pub enum DistanceRange {
 // TODO: Possibly relocate this to src/world/common.rs as it's unclear if we'll need this in more places, so it was placed here for now.
 #[binrw]
 #[brw(repr(u16))]
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum ChatChannel {
     #[default]
     Say = 10,

--- a/src/ipc/chat/client/mod.rs
+++ b/src/ipc/chat/client/mod.rs
@@ -64,17 +64,15 @@ mod tests {
     /// Ensure that the IPC data size as reported matches up with what we write
     #[test]
     fn client_chat_ipc_sizes() {
-        let ipc_types = [
-            (
-                ClientChatIpcType::SendTellMessage,
-                ClientChatIpcData::SendTellMessage(SendTellMessage {
-                    origin_world_id: 0,
-                    recipient_world_id: 0,
-                    recipient_name: "".to_string(),
-                    message: "".to_string(),
-                }),
-            ),
-        ];
+        let ipc_types = [(
+            ClientChatIpcType::SendTellMessage,
+            ClientChatIpcData::SendTellMessage(SendTellMessage {
+                origin_world_id: 0,
+                recipient_world_id: 0,
+                recipient_name: "".to_string(),
+                message: "".to_string(),
+            }),
+        )];
 
         for (opcode, ipc) in &ipc_types {
             let mut cursor = Cursor::new(Vec::new());

--- a/src/ipc/chat/client/mod.rs
+++ b/src/ipc/chat/client/mod.rs
@@ -64,15 +64,16 @@ mod tests {
     /// Ensure that the IPC data size as reported matches up with what we write
     #[test]
     fn client_chat_ipc_sizes() {
-        let ipc_types = [(
-            ClientChatIpcType::SendTellMessage,
-            ClientChatIpcData::SendTellMessage(SendTellMessage {
-                origin_world_id: 0,
-                recipient_world_id: 0,
-                recipient_name: "".to_string(),
-                message: "".to_string(),
-            }),
-        )];
+        let ipc_types = [
+            (
+                ClientChatIpcType::SendTellMessage,
+                ClientChatIpcData::SendTellMessage(SendTellMessage::default()),
+            ),
+            (
+                ClientChatIpcType::SendPartyMessage,
+                ClientChatIpcData::SendPartyMessage(SendPartyMessage::default()),
+            ),
+        ];
 
         for (opcode, ipc) in &ipc_types {
             let mut cursor = Cursor::new(Vec::new());

--- a/src/ipc/chat/client/mod.rs
+++ b/src/ipc/chat/client/mod.rs
@@ -1,6 +1,12 @@
 use binrw::binrw;
 use paramacro::opcode_data;
 
+mod send_tell_message;
+pub use send_tell_message::SendTellMessage;
+
+mod send_party_message;
+pub use send_party_message::SendPartyMessage;
+
 use crate::{
     opcodes::ClientChatIpcType,
     packet::{IPC_HEADER_SIZE, IpcSegment, ReadWriteIpcOpcode, ReadWriteIpcSegment},
@@ -28,9 +34,11 @@ impl ReadWriteIpcSegment for ClientChatIpcSegment {
 
 #[opcode_data(ClientChatIpcType)]
 #[binrw]
-#[br(import(_magic: &ClientChatIpcType, size: &u32))]
+#[br(import(magic: &ClientChatIpcType, size: &u32))]
 #[derive(Debug, Clone)]
 pub enum ClientChatIpcData {
+    SendTellMessage(SendTellMessage),
+    SendPartyMessage(SendPartyMessage),
     Unknown {
         #[br(count = size - 32)]
         unk: Vec<u8>,
@@ -41,6 +49,51 @@ impl Default for ClientChatIpcData {
     fn default() -> Self {
         Self::Unknown {
             unk: Vec::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use binrw::BinWrite;
+
+    use super::*;
+
+    /// Ensure that the IPC data size as reported matches up with what we write
+    #[test]
+    fn client_chat_ipc_sizes() {
+        let ipc_types = [
+            (
+                ClientChatIpcType::SendTellMessage,
+                ClientChatIpcData::SendTellMessage(SendTellMessage {
+                    origin_world_id: 0,
+                    recipient_world_id: 0,
+                    recipient_name: "".to_string(),
+                    message: "".to_string(),
+                }),
+            ),
+        ];
+
+        for (opcode, ipc) in &ipc_types {
+            let mut cursor = Cursor::new(Vec::new());
+
+            let ipc_segment = ClientChatIpcSegment {
+                op_code: opcode.clone(),
+                data: ipc.clone(),
+                ..Default::default()
+            };
+            ipc_segment.write_le(&mut cursor).unwrap();
+
+            let buffer = cursor.into_inner();
+
+            assert_eq!(
+                buffer.len(),
+                ipc_segment.calc_size() as usize,
+                "{:#?} did not match size!",
+                opcode
+            );
         }
     }
 }

--- a/src/ipc/chat/client/send_party_message.rs
+++ b/src/ipc/chat/client/send_party_message.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 use crate::common::{read_string, write_string};
 
 #[binrw]
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct SendPartyMessage {
     pub party_id: u64,
 

--- a/src/ipc/chat/client/send_party_message.rs
+++ b/src/ipc/chat/client/send_party_message.rs
@@ -1,0 +1,15 @@
+use binrw::binrw;
+
+use crate::common::{read_string, write_string};
+
+#[binrw]
+#[derive(Debug, Clone)]
+pub struct SendPartyMessage {
+    pub party_id: u64,
+
+    #[br(count = 1024)]
+    #[bw(pad_size_to = 1024)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    pub message: String,
+}

--- a/src/ipc/chat/client/send_tell_message.rs
+++ b/src/ipc/chat/client/send_tell_message.rs
@@ -3,18 +3,21 @@ use binrw::binrw;
 use crate::common::{read_string, write_string};
 
 #[binrw]
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SendTellMessage {
     #[brw(pad_before = 8)]
     pub origin_world_id: u16,
+
     #[brw(pad_before = 6)]
     pub recipient_world_id: u16,
+
     #[br(count = 32)]
     #[bw(pad_size_to = 32)]
     #[br(map = read_string)]
     #[bw(map = write_string)]
     #[brw(pad_before = 1)]
     pub recipient_name: String,
+
     #[br(count = 1024)]
     #[bw(pad_size_to = 1024)]
     #[br(map = read_string)]

--- a/src/ipc/chat/client/send_tell_message.rs
+++ b/src/ipc/chat/client/send_tell_message.rs
@@ -1,0 +1,24 @@
+use binrw::binrw;
+
+use crate::common::{read_string, write_string};
+
+#[binrw]
+#[derive(Debug, Clone, Default)]
+pub struct SendTellMessage {
+    #[brw(pad_before = 8)]
+    pub origin_world_id: u16,
+    #[brw(pad_before = 6)]
+    pub recipient_world_id: u16,
+    #[br(count = 32)]
+    #[bw(pad_size_to = 32)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    #[brw(pad_before = 1)]
+    pub recipient_name: String,
+    #[br(count = 1024)]
+    #[bw(pad_size_to = 1024)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    #[brw(pad_after = 5)]
+    pub message: String,
+}

--- a/src/ipc/chat/server/mod.rs
+++ b/src/ipc/chat/server/mod.rs
@@ -68,43 +68,44 @@ mod tests {
     /// Ensure that the IPC data size as reported matches up with what we write
     #[test]
     fn server_chat_ipc_sizes() {
-        let ipc_types = [(
-            ServerChatIpcType::LoginReply,
-            ServerChatIpcData::LoginReply {
-                timestamp: 0,
-                sid: 0,
-            },
-        ),
-        (
-            ServerChatIpcType::TellMessage,
-            ServerChatIpcData::TellMessage(TellMessage {
-                sender_account_id: 0,
-                unk2: 0,
-                unk3: 0,
-                unk4: 0,
-                sender_world_id: 0,
-                flags: 0,
-                sender_name: "".to_string(),
-                message: "".to_string(),
-            }),
-        ),
-        (
-            ServerChatIpcType::PartyMessage,
-            ServerChatIpcData::PartyMessage(PartyMessage {
-                party_id: 0,
-                sender_account_id: 0,
-                unk1: 0,
-                unk2: 0,
-                unk3: 0,
-                unk4: 0,
+        let ipc_types = [
+            (
+                ServerChatIpcType::LoginReply,
+                ServerChatIpcData::LoginReply {
+                    timestamp: 0,
+                    sid: 0,
+                },
+            ),
+            (
+                ServerChatIpcType::TellMessage,
+                ServerChatIpcData::TellMessage(TellMessage {
+                    sender_account_id: 0,
+                    unk2: 0,
+                    unk3: 0,
+                    unk4: 0,
+                    sender_world_id: 0,
+                    flags: 0,
+                    sender_name: "".to_string(),
+                    message: "".to_string(),
+                }),
+            ),
+            (
+                ServerChatIpcType::PartyMessage,
+                ServerChatIpcData::PartyMessage(PartyMessage {
+                    party_id: 0,
+                    sender_account_id: 0,
+                    unk1: 0,
+                    unk2: 0,
+                    unk3: 0,
+                    unk4: 0,
 
-                sender_actor_id: 0,
-                sender_world_id: 0,
-                sender_name: "".to_string(),
-                message: "".to_string(),
-            }),
-        ),
-    ];
+                    sender_actor_id: 0,
+                    sender_world_id: 0,
+                    sender_name: "".to_string(),
+                    message: "".to_string(),
+                }),
+            ),
+        ];
 
         for (opcode, ipc) in &ipc_types {
             let mut cursor = Cursor::new(Vec::new());

--- a/src/ipc/chat/server/mod.rs
+++ b/src/ipc/chat/server/mod.rs
@@ -78,32 +78,11 @@ mod tests {
             ),
             (
                 ServerChatIpcType::TellMessage,
-                ServerChatIpcData::TellMessage(TellMessage {
-                    sender_account_id: 0,
-                    unk2: 0,
-                    unk3: 0,
-                    unk4: 0,
-                    sender_world_id: 0,
-                    flags: 0,
-                    sender_name: "".to_string(),
-                    message: "".to_string(),
-                }),
+                ServerChatIpcData::TellMessage(TellMessage::default()),
             ),
             (
                 ServerChatIpcType::PartyMessage,
-                ServerChatIpcData::PartyMessage(PartyMessage {
-                    party_id: 0,
-                    sender_account_id: 0,
-                    unk1: 0,
-                    unk2: 0,
-                    unk3: 0,
-                    unk4: 0,
-
-                    sender_actor_id: 0,
-                    sender_world_id: 0,
-                    sender_name: "".to_string(),
-                    message: "".to_string(),
-                }),
+                ServerChatIpcData::PartyMessage(PartyMessage::default()),
             ),
         ];
 

--- a/src/ipc/chat/server/mod.rs
+++ b/src/ipc/chat/server/mod.rs
@@ -6,6 +6,12 @@ use crate::{
     packet::{IPC_HEADER_SIZE, IpcSegment, ReadWriteIpcOpcode, ReadWriteIpcSegment},
 };
 
+mod tell_message;
+pub use tell_message::TellMessage;
+
+mod party_message;
+pub use party_message::PartyMessage;
+
 pub type ServerChatIpcSegment = IpcSegment<ServerChatIpcType, ServerChatIpcData>;
 
 impl ReadWriteIpcSegment for ServerChatIpcSegment {
@@ -35,6 +41,8 @@ pub enum ServerChatIpcData {
         timestamp: u32,
         sid: u32,
     },
+    TellMessage(TellMessage),
+    PartyMessage(PartyMessage),
     Unknown {
         #[br(count = size - 32)]
         unk: Vec<u8>,
@@ -66,7 +74,37 @@ mod tests {
                 timestamp: 0,
                 sid: 0,
             },
-        )];
+        ),
+        (
+            ServerChatIpcType::TellMessage,
+            ServerChatIpcData::TellMessage(TellMessage {
+                sender_account_id: 0,
+                unk2: 0,
+                unk3: 0,
+                unk4: 0,
+                sender_world_id: 0,
+                flags: 0,
+                sender_name: "".to_string(),
+                message: "".to_string(),
+            }),
+        ),
+        (
+            ServerChatIpcType::PartyMessage,
+            ServerChatIpcData::PartyMessage(PartyMessage {
+                party_id: 0,
+                sender_account_id: 0,
+                unk1: 0,
+                unk2: 0,
+                unk3: 0,
+                unk4: 0,
+
+                sender_actor_id: 0,
+                sender_world_id: 0,
+                sender_name: "".to_string(),
+                message: "".to_string(),
+            }),
+        ),
+    ];
 
         for (opcode, ipc) in &ipc_types {
             let mut cursor = Cursor::new(Vec::new());

--- a/src/ipc/chat/server/party_message.rs
+++ b/src/ipc/chat/server/party_message.rs
@@ -1,0 +1,31 @@
+use binrw::binrw;
+
+use crate::common::{read_string, write_string};
+
+#[binrw]
+#[derive(Debug, Clone)]
+pub struct PartyMessage {
+    pub party_id: u64,
+    pub sender_account_id: u32,
+    pub unk1: u32,
+    pub unk2: u32,
+    pub unk3: u16,
+    pub unk4: u16,
+
+    pub sender_actor_id: u32,
+    pub sender_world_id: u16,
+
+    #[br(count = 32)]
+    #[bw(pad_size_to = 32)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    #[brw(pad_before = 1)]
+    pub sender_name: String,
+
+    #[br(count = 1024)]
+    #[bw(pad_size_to = 1024)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    #[brw(pad_after = 1)]
+    pub message: String,
+}

--- a/src/ipc/chat/server/party_message.rs
+++ b/src/ipc/chat/server/party_message.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 use crate::common::{read_string, write_string};
 
 #[binrw]
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct PartyMessage {
     pub party_id: u64,
     pub sender_account_id: u32,

--- a/src/ipc/chat/server/tell_message.rs
+++ b/src/ipc/chat/server/tell_message.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 use crate::common::{read_string, write_string};
 
 #[binrw]
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct TellMessage {
     pub sender_account_id: u32,
     pub unk2: u32,

--- a/src/ipc/chat/server/tell_message.rs
+++ b/src/ipc/chat/server/tell_message.rs
@@ -10,12 +10,15 @@ pub struct TellMessage {
     pub unk3: u32,
     pub unk4: u32,
     pub sender_world_id: u16,
-    pub flags: u8, // If it's a GM tell or not
+    /// Indicates if it's a GM tell or not.
+    pub flags: u8,
+
     #[br(count = 32)]
     #[bw(pad_size_to = 32)]
     #[br(map = read_string)]
     #[bw(map = write_string)]
     pub sender_name: String,
+
     #[br(count = 1024)]
     #[bw(pad_size_to = 1024)]
     #[br(map = read_string)]

--- a/src/ipc/chat/server/tell_message.rs
+++ b/src/ipc/chat/server/tell_message.rs
@@ -1,0 +1,25 @@
+use binrw::binrw;
+
+use crate::common::{read_string, write_string};
+
+#[binrw]
+#[derive(Debug, Clone, Default)]
+pub struct TellMessage {
+    pub sender_account_id: u32,
+    pub unk2: u32,
+    pub unk3: u32,
+    pub unk4: u32,
+    pub sender_world_id: u16,
+    pub flags: u8, // If it's a GM tell or not
+    #[br(count = 32)]
+    #[bw(pad_size_to = 32)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    pub sender_name: String,
+    #[br(count = 1024)]
+    #[bw(pad_size_to = 1024)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    #[brw(pad_after = 5)]
+    pub message: String,
+}

--- a/src/ipc/zone/client/mod.rs
+++ b/src/ipc/zone/client/mod.rs
@@ -4,8 +4,8 @@ use paramacro::opcode_data;
 mod action_request;
 pub use crate::ipc::zone::client::action_request::ActionRequest;
 
-mod chat_message;
-pub use chat_message::ChatMessage;
+mod send_chat_message;
+pub use send_chat_message::SendChatMessage;
 
 mod client_trigger;
 pub use crate::ipc::zone::client::client_trigger::{ClientTrigger, ClientTriggerCommand};
@@ -102,7 +102,7 @@ pub enum ClientZoneIpcData {
         // TODO: full of possibly interesting information
         unk: [u8; 8],
     },
-    ChatMessage(ChatMessage),
+    SendChatMessage(SendChatMessage),
     GMCommand {
         command: u32,
         arg0: u32,
@@ -329,8 +329,8 @@ mod tests {
                 ClientZoneIpcData::Disconnected { unk: [0; 8] },
             ),
             (
-                ClientZoneIpcType::ChatMessage,
-                ClientZoneIpcData::ChatMessage(ChatMessage::default()),
+                ClientZoneIpcType::SendChatMessage,
+                ClientZoneIpcData::SendChatMessage(SendChatMessage::default()),
             ),
             (
                 ClientZoneIpcType::GMCommand,

--- a/src/ipc/zone/client/send_chat_message.rs
+++ b/src/ipc/zone/client/send_chat_message.rs
@@ -1,19 +1,17 @@
 use binrw::binrw;
 
-use crate::common::{read_string, write_string};
+use crate::common::{ChatChannel, Position, read_string, write_string};
 
 #[binrw]
 #[derive(Debug, Clone, Default)]
-pub struct ChatMessage {
-    // TODO: incomplete
+pub struct SendChatMessage {
     #[brw(pad_before = 4)] // empty
     pub actor_id: u32,
 
-    #[brw(pad_before = 4)] // empty
-    pub timestamp: u32,
+    pub pos: Position,
+    pub rotation: f32,
 
-    #[brw(pad_before = 8)] // NOT empty
-    pub channel: u16,
+    pub channel: ChatChannel,
 
     #[brw(pad_after = 6)] // seems to be junk?
     #[br(count = 1024)]

--- a/src/ipc/zone/client/send_chat_message.rs
+++ b/src/ipc/zone/client/send_chat_message.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 use crate::common::{ChatChannel, Position, read_string, write_string};
 
 #[binrw]
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SendChatMessage {
     #[brw(pad_before = 4)] // empty
     pub actor_id: u32,

--- a/src/ipc/zone/server/actor_control.rs
+++ b/src/ipc/zone/server/actor_control.rs
@@ -212,7 +212,7 @@ impl Default for ActorControlSelf {
 #[binrw]
 #[derive(Debug, Clone)]
 pub struct ActorControlTarget {
-    #[brw(pad_size_to = 28)] // take into account categories without params
+    #[brw(pad_size_to = 32)] // take into account categories without params
     pub category: ActorControlCategory,
 }
 

--- a/src/ipc/zone/server/chat_message.rs
+++ b/src/ipc/zone/server/chat_message.rs
@@ -3,7 +3,7 @@ use binrw::binrw;
 use crate::common::{ChatChannel, read_string, write_string};
 
 #[binrw]
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ChatMessage {
     pub sender_account_id: u32,
     pub unk2: u32,

--- a/src/ipc/zone/server/chat_message.rs
+++ b/src/ipc/zone/server/chat_message.rs
@@ -1,6 +1,6 @@
 use binrw::binrw;
 
-use crate::common::{ChatChannel, /*Position,*/ read_string, write_string};
+use crate::common::{ChatChannel, read_string, write_string};
 
 #[binrw]
 #[derive(Debug, Clone, Default)]

--- a/src/ipc/zone/server/chat_message.rs
+++ b/src/ipc/zone/server/chat_message.rs
@@ -1,0 +1,30 @@
+use binrw::binrw;
+
+use crate::common::{ChatChannel, /*Position,*/ read_string, write_string};
+
+#[binrw]
+#[derive(Debug, Clone, Default)]
+pub struct ChatMessage {
+    pub sender_account_id: u32,
+    pub unk2: u32,
+    pub unk3: u32,
+    pub unk4: u32,
+
+    pub sender_actor_id: u32,
+
+    pub sender_world_id: u16,
+    pub channel: ChatChannel,
+
+    #[br(count = 32)]
+    #[bw(pad_size_to = 32)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    pub sender_name: String,
+
+    #[brw(pad_after = 6)] // seems to be junk?
+    #[br(count = 1024)]
+    #[bw(pad_size_to = 1024)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    pub message: String,
+}

--- a/src/ipc/zone/server/mod.rs
+++ b/src/ipc/zone/server/mod.rs
@@ -79,6 +79,9 @@ pub use effect_result::{EffectEntry, EffectResult};
 mod condition;
 pub use condition::{Condition, Conditions};
 
+mod chat_message;
+pub use chat_message::ChatMessage;
+
 use crate::COMPLETED_LEVEQUEST_BITMASK_SIZE;
 use crate::COMPLETED_QUEST_BITMASK_SIZE;
 use crate::TITLE_UNLOCK_BITMASK_SIZE;
@@ -458,6 +461,7 @@ pub enum ServerZoneIpcData {
         // TODO: fill this out, each entry appears to be 56 bytes long.
         unk: [u8; 448],
     },
+    ChatMessage(ChatMessage),
     Unknown {
         #[br(count = size - 32)]
         unk: Vec<u8>,

--- a/src/world/chat_handler.rs
+++ b/src/world/chat_handler.rs
@@ -4,7 +4,7 @@ use crate::{
     ERR_INVENTORY_ADD_FAILED, ITEM_CONDITION_MAX,
     common::ItemInfoQuery,
     inventory::{Item, Storage},
-    ipc::zone::client::ChatMessage,
+    ipc::zone::client::SendChatMessage,
     ipc::zone::server::{Condition, Conditions, GameMasterRank},
     world::{EventFinishType, ToServer},
 };
@@ -17,7 +17,7 @@ impl ChatHandler {
     /// Returns true if the command is handled, otherwise false.
     pub async fn handle_chat_message(
         connection: &mut ZoneConnection,
-        chat_message: &ChatMessage,
+        chat_message: &SendChatMessage,
     ) -> bool {
         if connection.player_data.gm_rank == GameMasterRank::NormalUser {
             tracing::info!("Rejecting debug command because the user is not GM!");


### PR DESCRIPTION
-The size of ACTarget is 32, not 28.
-Documented client opcode SendChatMessage, renamed from ChatMessage
-The server will take over ChatMessage, keeping a naming convention used by other chat segments sent by the server
-Documented client opcodes SendTellmessage and SendPartyMessage
-Documented server opcodes TellMessage and PartyMessage
-Add ipc size tests for ipc::chat::client