### PR TITLE
Improve accuracy of the Equip sequence, and actually fix subweapons not displaying

### DIFF
--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -649,14 +649,9 @@ async fn client_loop(
 
                                                 connection.player_data.inventory.process_action(action);
 
-                                                // if updated equipped items, we have to process that
+                                                // If the client modified their equipped items, we have to process that
                                                 if action.src_storage_id == ContainerType::Equipped || action.dst_storage_id == ContainerType::Equipped {
                                                     connection.inform_equip().await;
-                                                    connection.actor_control_self(ActorControlSelf {
-                                                        category: ActorControlCategory::SetItemLevel {
-                                                            level: connection.player_data.inventory.equipped.calculate_item_level() as u32,
-                                                        }
-                                                    }).await;
                                                 }
 
                                                 if action.operation_type == ItemOperationKind::Discard {
@@ -1122,7 +1117,7 @@ async fn client_loop(
                     FromServer::ActionComplete(request) => connection.execute_action(request, &mut lua_player).await,
                     FromServer::ActionCancelled() => connection.cancel_action().await,
                     FromServer::UpdateConfig(actor_id, config) => connection.update_config(actor_id, config).await,
-                    FromServer::ActorEquip(actor_id, main_weapon_id, model_ids) => connection.update_equip(actor_id, main_weapon_id, model_ids).await,
+                    FromServer::ActorEquip(actor_id, main_weapon_id, sub_weapon_id, model_ids) => connection.update_equip(actor_id, main_weapon_id, sub_weapon_id, model_ids).await,
                     FromServer::ReplayPacket(segment) => connection.send_segment(segment).await,
                     FromServer::LoseEffect(effect_id, effect_param, effect_source_actor_id) => connection.lose_effect(effect_id, effect_param, effect_source_actor_id, &mut lua_player).await,
                     FromServer::Conditions(conditions) => {

--- a/src/common/gamedata.rs
+++ b/src/common/gamedata.rs
@@ -264,7 +264,10 @@ impl GameData {
     /// Gets the sub model ID for a given item ID.
     pub fn get_sub_model_id(&mut self, item_id: u32) -> Option<u64> {
         if let Some(item_info) = self.get_item_info(ItemInfoQuery::ById(item_id)) {
-            return Some(item_info.sub_model_id);
+            // Only return an id if the item actually has a sub model.
+            if item_info.sub_model_id != 0 {
+                return Some(item_info.sub_model_id);
+            }
         }
 
         None

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -408,7 +408,7 @@ impl Inventory {
             model
         } else {
             game_data
-                .get_sub_model_id(self.equipped.off_hand.apparent_id())
+                .get_primary_model_id(self.equipped.off_hand.apparent_id()).
                 .unwrap_or(0)
         }
     }

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -408,7 +408,7 @@ impl Inventory {
             model
         } else {
             game_data
-                .get_primary_model_id(self.equipped.off_hand.apparent_id()).
+                .get_primary_model_id(self.equipped.off_hand.apparent_id())
                 .unwrap_or(0)
         }
     }

--- a/src/world/common.rs
+++ b/src/world/common.rs
@@ -45,7 +45,7 @@ pub enum FromServer {
     /// Update an actor's equip display flags.
     UpdateConfig(u32, Config),
     /// Update an actor's model IDs.
-    ActorEquip(u32, u64, [u32; 10]),
+    ActorEquip(u32, u64, u64, [u32; 10]),
     /// Informs the connection to replay packet data to the client.
     ReplayPacket(PacketSegment<ServerZoneIpcSegment>),
     /// The player should lose this effect.
@@ -118,7 +118,7 @@ pub enum ToServer {
     /// We want to update our own equip display flags.
     Config(ClientId, u32, Config),
     /// Tell the server what models IDs we have equipped.
-    Equip(ClientId, u32, u64, [u32; 10]),
+    Equip(ClientId, u32, u64, u64, [u32; 10]),
     /// Begins a packet replay.
     BeginReplay(ClientId, String),
     /// The player gains an effect.

--- a/src/world/connection.rs
+++ b/src/world/connection.rs
@@ -680,7 +680,13 @@ impl ZoneConnection {
         }
     }
 
-    pub async fn update_equip(&mut self, actor_id: u32, main_weapon_id: u64, sub_weapon_id: u64, model_ids: [u32; 10]) {
+    pub async fn update_equip(
+        &mut self,
+        actor_id: u32,
+        main_weapon_id: u64,
+        sub_weapon_id: u64,
+        model_ids: [u32; 10],
+    ) {
         let chara_details = self.database.find_chara_make(self.player_data.content_id);
         self.send_stats(&chara_details).await;
         let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::Equip(Equip {
@@ -703,8 +709,9 @@ impl ZoneConnection {
             self.actor_control_self(ActorControlSelf {
                 category: ActorControlCategory::SetItemLevel {
                     level: self.player_data.inventory.equipped.calculate_item_level() as u32,
-                }
-            }).await;
+                },
+            })
+            .await;
             // Uknown what this is, it's seen when (un)equipping stuff.
             self.actor_control_self(ActorControlSelf {
                 category: ActorControlCategory::Unknown {
@@ -713,10 +720,11 @@ impl ZoneConnection {
                     param2: 0,
                     param3: 0,
                     param4: 0,
-                }
-            }).await;
+                },
+            })
+            .await;
         }
-        
+
         self.process_effects_list().await;
         self.update_class_info().await;
     }

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -1139,7 +1139,7 @@ pub async fn server_main_loop(mut recv: Receiver<ToServer>) -> Result<(), std::i
                     }
                 }
             }
-            ToServer::Equip(_from_id, from_actor_id, main_weapon_id, model_ids) => {
+            ToServer::Equip(_from_id, from_actor_id, main_weapon_id, sub_weapon_id, model_ids) => {
                 // update their stored state so it's correctly sent on new spawns
                 {
                     let mut data = data.lock().unwrap();
@@ -1157,6 +1157,7 @@ pub async fn server_main_loop(mut recv: Receiver<ToServer>) -> Result<(), std::i
                     };
 
                     player.common.main_weapon_model = main_weapon_id;
+                    player.common.sec_weapon_model = sub_weapon_id;
                     player.common.models = model_ids;
                 }
 
@@ -1165,7 +1166,7 @@ pub async fn server_main_loop(mut recv: Receiver<ToServer>) -> Result<(), std::i
                 for (id, (handle, _)) in &mut network.clients {
                     let id = *id;
 
-                    let msg = FromServer::ActorEquip(from_actor_id, main_weapon_id, model_ids);
+                    let msg = FromServer::ActorEquip(from_actor_id, main_weapon_id, sub_weapon_id, model_ids);
 
                     if handle.send(msg).is_err() {
                         to_remove.push(id);

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -1166,7 +1166,12 @@ pub async fn server_main_loop(mut recv: Receiver<ToServer>) -> Result<(), std::i
                 for (id, (handle, _)) in &mut network.clients {
                     let id = *id;
 
-                    let msg = FromServer::ActorEquip(from_actor_id, main_weapon_id, sub_weapon_id, model_ids);
+                    let msg = FromServer::ActorEquip(
+                        from_actor_id,
+                        main_weapon_id,
+                        sub_weapon_id,
+                        model_ids,
+                    );
 
                     if handle.send(msg).is_err() {
                         to_remove.push(id);


### PR DESCRIPTION
This does not fix the Glamourer crash, unfortunately. I don't know where the problem is at the moment.

As for fixing subweapons, it's simple: they don't have sub models ids at all (always 0), they only have main model ids, and main hand items that don't have a sub item always have a sub model id of 0, so we were always returning 0 on accident.