### PR TITLE
Fix the opcode for SocialListRequest

### DIFF
--- a/resources/data/opcodes.json
+++ b/resources/data/opcodes.json
@@ -509,7 +509,7 @@
         {
             "name": "SocialListRequest",
             "comment": "Sent by the client when it requests the friends list and other related info.",
-            "opcode": 834,
+            "opcode": 384,
             "size": 16
         },
         {


### PR DESCRIPTION
Now our trusty party list shows the bogus player again.