### PR TITLE
Move mdBook installation after CI cache is created

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,7 @@ jobs:
       id: cache-deps
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
+          ~/.cargo
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
@@ -44,18 +41,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - run: |
-        cargo install --git https://github.com/rust-lang/mdBook.git mdbook
     - uses: actions/cache@v4
       id: cache-deps
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
+          ~/.cargo
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - run: |
+        cargo install --git https://github.com/rust-lang/mdBook.git mdbook
     - uses: robinraju/release-downloader@v1
       if: runner.os == 'Linux'
       with:


### PR DESCRIPTION
This should hopefully make re-runs faster, because installation normally takes 4+ minutes.