### PR TITLE
Undo accidental removal of player position and rotation updates

### DIFF
--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -447,6 +447,9 @@ async fn client_loop(
                                                 }
                                             }
                                             ClientZoneIpcData::UpdatePositionHandler { position, rotation, anim_type, anim_state, jump_state, } => {
+                                                connection.player_data.rotation = *rotation;
+                                                connection.player_data.position = *position;
+                                                
                                                 connection.handle.send(ToServer::ActorMoved(connection.id, connection.player_data.actor_id, *position, *rotation, *anim_type, *anim_state, *jump_state)).await;
                                             }
                                             ClientZoneIpcData::LogOut { .. } => {


### PR DESCRIPTION
Fixes positions not being saved when logging out. I broke this on accident in the movement overhaul.