### PR TITLE
Fix the minion bitmask size for 7.3x

### DIFF
--- a/src/ipc/zone/server/player_setup.rs
+++ b/src/ipc/zone/server/player_setup.rs
@@ -163,8 +163,8 @@ pub struct PlayerStatus {
     #[bw(pad_size_to = 41)]
     pub unknown85e: Vec<u8>,
     // meh, this is where i put all of the new data
-    #[br(count = 153)]
-    #[bw(pad_size_to = 153)]
+    #[br(count = 116)]
+    #[bw(pad_size_to = 116)]
     pub unknown948: Vec<u8>,
 
     // unlocked status

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,7 @@ pub const TRIAL_ARRAY_SIZE: usize = 14;
 pub const PVP_ARRAY_SIZE: usize = 7;
 
 /// The size of the minion bitmask.
-// TODO & FIXME: This is wrong as of 7.31h1, a large number of minions are missing.
-pub const MINION_BITMASK_SIZE: usize = 60;
+pub const MINION_BITMASK_SIZE: usize = 97;
 
 /// The maximum durability of an item.
 pub const ITEM_CONDITION_MAX: u16 = 30000;


### PR DESCRIPTION
I didn't notice any adverse effects by adjusting this but your results may vary. That said, it should now display all ~548 minions correctly.