### PR TITLE
Allow Duty Recorder to be used by the client

### DIFF
--- a/src/ipc/zone/client/client_trigger.rs
+++ b/src/ipc/zone/client/client_trigger.rs
@@ -127,6 +127,12 @@ pub enum ClientTriggerCommand {
     #[brw(magic = 0x232Du32)]
     SetDistanceRange { range: DistanceRange },
 
+    #[brw(magic = 0x07BCu32)]
+    BeginContentsReplay {},
+
+    #[brw(magic = 0x07BDu32)]
+    EndContentsReplay {},
+
     // Sent whenever the client tries to begin a Hall of the Novice exercise.
     #[brw(magic = 0x0802u32)]
     BeginNoviceExercise {

--- a/src/ipc/zone/server/actor_control.rs
+++ b/src/ipc/zone/server/actor_control.rs
@@ -199,6 +199,16 @@ pub enum ActorControlCategory {
         unlocked: bool,
     },
 
+    #[brw(magic = 931u32)]
+    BeginContentsReplay {
+        unk1: u32, // Always 1
+    },
+
+    #[brw(magic = 932u32)]
+    EndContentsReplay {
+        unk1: u32, // Always 1
+    },
+
     Unknown {
         category: u32,
         param1: u32,

--- a/src/ipc/zone/server/condition.rs
+++ b/src/ipc/zone/server/condition.rs
@@ -10,6 +10,8 @@ pub enum Condition {
     None = 0,
     /// Seen when beginning a walk-in event.
     WalkInEvent = 6,
+    /// When the client starts watching a Duty Recorder replay.
+    ContentsReplay = 17,
     /// When the client is logging out.
     LoggingOut = 25,
 }

--- a/src/ipc/zone/server/init_zone.rs
+++ b/src/ipc/zone/server/init_zone.rs
@@ -12,7 +12,7 @@ pub struct InitZone {
     pub layer_set_id: u32,
     pub layout_id: u32,
     pub weather_id: u16, // index into Weather sheet probably?
-    pub unk_really: u16,
+    pub unk_really: u16, // If not 1, then the Duty Recorder window doesn't initialize in the client.
     pub unk_bitmask1: u8,
     /// Zero means "no obsfucation" (not really, but functionally yes.)
     /// To enable obsfucation, you need to set this to a constant that changes every patch. See lib.rs for the constant.

--- a/src/world/connection.rs
+++ b/src/world/connection.rs
@@ -549,6 +549,7 @@ impl ZoneConnection {
             let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::InitZone(InitZone {
                 territory_type: new_zone_id,
                 weather_id,
+                unk_really: 1,
                 obsfucation_mode: if config.world.enable_packet_obsfucation {
                     OBFUSCATION_ENABLED_MODE
                 } else {


### PR DESCRIPTION
- `unk_really` from InitZone needs to be set to 1, if not, then the client will not initialize the Duty Recorder window properly, and will not work even if it's forced to be opened.
- The client sends a ClientTrigger when starting to watch a replay, and when finished. Both receives a **Condition** and a **ActorControlSelf** packet in return.
- Since the game refers to Duty Recorder as `ContentsReplay` internally, that name has been adopted for naming the added enum values.

This is my first time contributing to something like this, specifically on Rust too, so the added logic may rely a bit too much on already existing code (although, it's been pointed out properly from where in comments).