### PR TITLE
Fix opcode value of RequestCrossworldLinkshells

### DIFF
--- a/resources/data/opcodes.json
+++ b/resources/data/opcodes.json
@@ -701,7 +701,7 @@
         {
             "name": "RequestCrossworldLinkshells",
             "comment": "Seems to happen when opening the Cross-world Linkshells window. Weird that it can do this, considering it's sent on login?",
-            "opcode": 888,
+            "opcode": 954,
             "size": 8
         },
         {


### PR DESCRIPTION
It's incorrect and conflicts with a party-related opcode.