### PR TITLE
Use u64s for account/user ids in general

### DIFF
--- a/resources/data/opcodes.json
+++ b/resources/data/opcodes.json
@@ -863,7 +863,7 @@
             "name": "RequestCreateCharacter",
             "comment": "Request the world server to create a character",
             "opcode": 1,
-            "size": 1056
+            "size": 1060
         },
         {
             "name": "CharacterCreated",
@@ -899,7 +899,7 @@
             "name": "RequestCharacterList",
             "comment": "Request the character list from the world server",
             "opcode": 7,
-            "size": 4
+            "size": 8
         },
         {
             "name": "RequestCharacterListRepsonse",
@@ -923,7 +923,7 @@
             "name": "ImportCharacter",
             "comment": "Request to import a character backup",
             "opcode": 11,
-            "size": 132
+            "size": 136
         },
         {
             "name": "RemakeCharacter",
@@ -947,7 +947,7 @@
             "name": "DeleteServiceAccount",
             "comment": "Removes the characters associated with a given service account.",
             "opcode": 15,
-            "size": 4
+            "size": 8
         },
         {
             "name": "RequestFullCharacterList",

--- a/src/bin/kawari-lobby.rs
+++ b/src/bin/kawari-lobby.rs
@@ -352,7 +352,6 @@ async fn main() {
                                             connection.selected_service_account = Some(
                                                 connection.service_accounts[*account_index as usize]
                                                     .id
-                                                    as u32,
                                             );
                                             connection.send_lobby_info(*sequence).await
                                         }

--- a/src/ipc/chat/server/party_message.rs
+++ b/src/ipc/chat/server/party_message.rs
@@ -6,11 +6,10 @@ use crate::common::{read_string, write_string};
 #[derive(Clone, Debug, Default)]
 pub struct PartyMessage {
     pub party_id: u64,
-    pub sender_account_id: u32,
+    pub sender_account_id: u64,
     pub unk1: u32,
-    pub unk2: u32,
+    pub unk2: u16,
     pub unk3: u16,
-    pub unk4: u16,
 
     pub sender_actor_id: u32,
     pub sender_world_id: u16,

--- a/src/ipc/chat/server/tell_message.rs
+++ b/src/ipc/chat/server/tell_message.rs
@@ -5,10 +5,9 @@ use crate::common::{CHAR_NAME_MAX_LENGTH, read_string, write_string};
 #[binrw]
 #[derive(Clone, Debug, Default)]
 pub struct TellMessage {
-    pub sender_account_id: u32,
+    pub sender_account_id: u64,
+    pub unk1: u32,
     pub unk2: u32,
-    pub unk3: u32,
-    pub unk4: u32,
     pub sender_world_id: u16,
     /// Indicates if it's a GM tell or not.
     pub flags: u8,
@@ -31,19 +30,11 @@ pub struct TellMessage {
 #[derive(Clone, Debug, Default)]
 pub struct TellNotFoundError {
     /// Assumed.
-    pub recipient_account_id: u32,
-    /// Commonly seen as 0x0000.
-    pub unk1: u16,
-    /// Commonly seen as 0x0040.
-    pub unk2: u16,
+    pub recipient_account_id: u64,
     /// Assumed.
-    pub sender_account_id: u32,
-    /// Commonly seen as 0x0017.
-    pub unk3: u16,
-    /// Commonly seen as 0x0040.
-    pub unk4: u16,
+    pub sender_account_id: u64,
     /// Commonly seen as 0x68.
-    pub unk5: u32,
+    pub unk: u32,
     /// The recipient's world id.
     pub recipient_world_id: u16,
     /// The recipient's name.

--- a/src/ipc/kawari/mod.rs
+++ b/src/ipc/kawari/mod.rs
@@ -17,7 +17,7 @@ pub type CustomIpcSegment =
 #[derive(Debug, Clone)]
 pub enum CustomIpcData {
     RequestCreateCharacter {
-        service_account_id: u32,
+        service_account_id: u64,
         #[bw(pad_size_to = CHAR_NAME_MAX_LENGTH)]
         #[br(count = CHAR_NAME_MAX_LENGTH)]
         #[br(map = read_string)]
@@ -52,7 +52,7 @@ pub enum CustomIpcData {
         free: bool,
     },
     RequestCharacterList {
-        service_account_id: u32,
+        service_account_id: u64,
     },
     RequestCharacterListRepsonse {
         #[bw(calc = characters.len() as u8)]
@@ -68,7 +68,7 @@ pub enum CustomIpcData {
         deleted: u8,
     },
     ImportCharacter {
-        service_account_id: u32,
+        service_account_id: u64,
         #[bw(pad_size_to = 128)]
         #[br(count = 128)]
         #[br(map = read_string)]
@@ -94,7 +94,7 @@ pub enum CustomIpcData {
         message: String,
     },
     DeleteServiceAccount {
-        service_account_id: u32,
+        service_account_id: u64,
     },
     RequestFullCharacterList {},
     FullCharacterListResponse {

--- a/src/ipc/lobby/client/mod.rs
+++ b/src/ipc/lobby/client/mod.rs
@@ -26,8 +26,7 @@ pub enum ClientLobbyIpcData {
         unk1: u8,
         unk2: u16,
         unk3: u32, // TODO: probably multiple params
-        account_id: u32,
-        unk4: u32,
+        account_id: u64,
     },
     GameLogin {
         sequence: u64,
@@ -97,9 +96,8 @@ mod tests {
                 account_index: 0,
                 unk1: 0,
                 unk2: 0,
-                account_id: 0,
                 unk3: 0,
-                unk4: 0,
+                account_id: 0,
             },
             ClientLobbyIpcData::GameLogin {
                 sequence: 0,

--- a/src/ipc/zone/black_list.rs
+++ b/src/ipc/zone/black_list.rs
@@ -4,8 +4,8 @@ use binrw::binrw;
 #[binrw]
 #[derive(Debug, Copy, Clone, Default)]
 pub struct BlacklistedCharacter {
-    /// The blocked character's content id, or account id, unclear which.
-    pub content_id: u64,
+    /// The blocked character's account id.
+    pub account_id: u64,
     /// An unknown flag/boolean, possibly related to blocking chat messages, or visibility when in the same zone.
     pub flag1: u16, // Assumed, seems to be set to 1
     // TODO: The padding after seems to be empty, but more testing needs to be done to see if it doesn't hold a world id or other info for players that aren't from the client's world

--- a/src/ipc/zone/server/chat_message.rs
+++ b/src/ipc/zone/server/chat_message.rs
@@ -5,10 +5,9 @@ use crate::common::{ChatChannel, read_string, write_string};
 #[binrw]
 #[derive(Clone, Debug, Default)]
 pub struct ChatMessage {
-    pub sender_account_id: u32,
+    pub sender_account_id: u64,
+    pub unk1: u32,
     pub unk2: u32,
-    pub unk3: u32,
-    pub unk4: u32,
 
     pub sender_actor_id: u32,
 

--- a/src/ipc/zone/server/player_spawn.rs
+++ b/src/ipc/zone/server/player_spawn.rs
@@ -8,9 +8,7 @@ use super::{CommonSpawn, GameMasterRank};
 #[brw(little)]
 #[derive(Debug, Clone, Default)]
 pub struct PlayerSpawn {
-    pub account_id: u32,
-
-    #[brw(pad_before = 4)] // always empty?
+    pub account_id: u64,
     pub content_id: u64,
 
     /// Index into the Title Excel sheet.

--- a/src/lobby/connection.rs
+++ b/src/lobby/connection.rs
@@ -27,7 +27,7 @@ pub struct LobbyConnection {
     pub stored_character_creation_name: String,
     pub world_name: String,
     pub service_accounts: Vec<ServiceAccount>,
-    pub selected_service_account: Option<u32>,
+    pub selected_service_account: Option<u64>,
     pub last_keep_alive: Instant,
 }
 

--- a/src/world/common.rs
+++ b/src/world/common.rs
@@ -45,7 +45,7 @@ pub struct MessageInfo {
     /// The sender's actor id.
     pub sender_actor_id: u32,
     /// The sender's account id. Likely used by the client to know to ignore the message if this player is blocked.
-    pub sender_account_id: u32,
+    pub sender_account_id: u64,
     /// The sender's home world id. Used for purposes of displaying their home world in the chat window.
     pub sender_world_id: u16,
     /// The sender's name.

--- a/src/world/database.rs
+++ b/src/world/database.rs
@@ -106,7 +106,7 @@ impl WorldDatabase {
     pub fn import_character(
         &self,
         game_data: &mut GameData,
-        service_account_id: u32,
+        service_account_id: u64,
         path: &str,
     ) -> Result<(), ImportError> {
         tracing::info!("Importing character backup from {path}...");
@@ -335,7 +335,7 @@ impl WorldDatabase {
         let mut stmt = connection
             .prepare("SELECT content_id, service_account_id FROM characters WHERE actor_id = ?1")
             .unwrap();
-        let (content_id, account_id): (u64, u32) = stmt
+        let (content_id, account_id): (u64, u64) = stmt
             .query_row((actor_id,), |row| Ok((row.get(0)?, row.get(1)?)))
             .unwrap();
 
@@ -479,7 +479,7 @@ impl WorldDatabase {
 
     pub fn get_character_list(
         &self,
-        service_account_id: u32,
+        service_account_id: u64,
         world_id: u16,
         world_name: &str,
         game_data: &mut GameData,
@@ -601,7 +601,7 @@ impl WorldDatabase {
     /// Gives (content_id, actor_id)
     pub fn create_player_data(
         &self,
-        service_account_id: u32,
+        service_account_id: u64,
         name: &str,
         chara_make_str: &str,
         city_state: u8,
@@ -754,7 +754,7 @@ impl WorldDatabase {
     }
 
     /// Deletes all character associated with the service account.
-    pub fn delete_characters(&self, service_account_id: u32) {
+    pub fn delete_characters(&self, service_account_id: u64) {
         let connection = self.connection.lock().unwrap();
 
         let content_actor_ids: Vec<(u32, u32)>;

--- a/src/world/zone_connection.rs
+++ b/src/world/zone_connection.rs
@@ -134,7 +134,7 @@ pub struct PlayerData {
     // Static data
     pub actor_id: u32,
     pub content_id: u64,
-    pub account_id: u32,
+    pub account_id: u64,
 
     pub classjob_id: u8,
     pub classjob_levels: [i32; CLASSJOB_ARRAY_SIZE],


### PR DESCRIPTION
This makes us consistent with ClientStructs and Sapphire (to my knowledge?). I didn't notice or find any obvious regressions with this, but it's possible I missed something.