### PR TITLE
Add party-related structs, and a couple misc. chat connection ones

### DIFF
--- a/resources/data/opcodes.json
+++ b/resources/data/opcodes.json
@@ -479,6 +479,42 @@
             "comment": "Sent by the server to inform clients about their free company's message of the day. May have additional uses?",
             "opcode": 922,
             "size": 200
+        },
+        {
+            "name": "CharaInfoFromContentIds",
+            "comment": "Sent by the server in response to RequestCharaInfoFromContentIds.",
+            "opcode": 407,
+            "size": 568
+        },
+        {
+            "name": "InviteCharacterResult",
+            "comment": "Sent by the server to inform the client about their own new invite to another character.",
+            "opcode": 574,
+            "size": 48
+        },
+        {
+            "name": "InviteUpdate",
+            "comment": "Sent by the server to inform the client of an invitation changing state.",
+            "opcode": 674,
+            "size": 72
+        },
+        {
+            "name": "PartyUpdate",
+            "comment": "Sent by the server when the party needs to be updated.",
+            "opcode": 908,
+            "size": 104
+        },
+        {
+            "name": "PartyList",
+            "comment": "Sent by the server when the party list needs to be updated.",
+            "opcode": 890,
+            "size": 3672
+        },
+        {
+            "name": "InviteReplyResult",
+            "comment": "Sent by the server to inform the client about its own invite reply.",
+            "opcode": 491,
+            "size": 48
         }
     ],
     "ClientZoneIpcType": [
@@ -739,8 +775,49 @@
             "comment": "Happens during initialization, informs the server what the client's language is set to.",
             "opcode": 120,
             "size": 8
+        },
+        {
+            "name": "RequestCharaInfoFromContentIds",
+            "comment": "Happens when the client requests more information about other characters, and only has their content id.",
+            "opcode": 686,
+            "size": 80
+        },
+        {
+            "name": "PartyLeave",
+            "comment": "Happens when the client leaves their party.",
+            "opcode": 617,
+            "size": 8
+        },
+        {
+            "name": "PartyDisband",
+            "comment": "Happens when the client disbands their party.",
+            "opcode": 635,
+            "size": 8
+        },
+        {
+            "name": "InviteCharacter",
+            "comment": "Happens when the client invites another player to a party, adds them to their friend list, etc.",
+            "opcode": 888,
+            "size": 48
+        },
+        {
+            "name": "InviteReply",
+            "comment": "Happens when the client responds to another player's party invitation.",
+            "opcode": 916,
+            "size": 16
+        },
+        {
+            "name": "PartyMemberKick",
+            "comment": "Sent by the client to remove another player from their party.",
+            "opcode": 498,
+            "size": 48
+        },
+        {
+            "name": "PartyChangeLeader",
+            "comment": "Sent by the client to relinquish leadership to another player in their party.",
+            "opcode": 276,
+            "size": 48
         }
-
     ],
     "ServerLobbyIpcType": [
         {
@@ -848,6 +925,18 @@
             "comment": "Sent by the server in response to a client sending a private message to another client that is offline.",
             "opcode": 112,
             "size": 56
+        },
+        {
+            "name": "JoinChannelResult",
+            "comment": "Presumably sent by the server in response to the client joining a chat channel: fc. linkshell, etc. Doesn't seem to be needed for party chat.",
+            "opcode": 200,
+            "size": 32
+        },
+        {
+            "name": "FreeCompanyEvent",
+            "comment": "Sent by the server in response to a free company-related event taking place: member logging in, logging out, etc.",
+            "opcode": 300,
+            "size": 104
         }
     ],
     "ClientChatIpcType": [
@@ -862,6 +951,12 @@
             "comment": "Sent by the client when sending a message to party chat.",
             "opcode": 101,
             "size": 1032
+        },
+        {
+            "name": "GetChannelList",
+            "comment": "Sent by the client, but its purpose is unknown at this time.",
+            "opcode": 104,
+            "size": 8
         }
     ],
     "CustomIpcType": [

--- a/src/bin/kawari-world.rs
+++ b/src/bin/kawari-world.rs
@@ -384,6 +384,9 @@ async fn client_chat_loop(
                                             ClientChatIpcData::SendPartyMessage(data) => {
                                                  tracing::info!("SendPartyMessage: {:#?} from {}", data, connection.actor_id);
                                             }
+                                            ClientChatIpcData::GetChannelList { unk } => {
+                                                tracing::info!("GetChannelList: {:#?} from {}", unk, connection.actor_id);
+                                            }
                                             ClientChatIpcData::Unknown { unk } => {
                                                 tracing::warn!("Unknown Chat packet {:?} recieved ({} bytes), this should be handled!", data.header.op_code, unk.len());
                                             }
@@ -1530,6 +1533,27 @@ async fn client_loop(
                                                 tracing::info!("Setting language to {language:?}!");
 
                                                 connection.client_language = *language;
+                                            }
+                                            ClientZoneIpcData::RequestCharaInfoFromContentIds { .. } => {
+                                                tracing::info!("Requesting character info from content ids is unimplemented");
+                                            }
+                                            ClientZoneIpcData::PartyLeave { .. } => {
+                                                tracing::info!("Leaving parties is unimplemented");
+                                            }
+                                            ClientZoneIpcData::PartyDisband { .. } => {
+                                                tracing::info!("Disbanding parties is unimplemented");
+                                            }
+                                            ClientZoneIpcData::PartyMemberKick { .. } => {
+                                                tracing::info!("Kicking members from parties is unimplemented");
+                                            }
+                                            ClientZoneIpcData::PartyChangeLeader { .. } => {
+                                                tracing::info!("Promoting other players to party leader is unimplemented");
+                                            }
+                                            ClientZoneIpcData::InviteCharacter { .. } => {
+                                                tracing::info!("Inviting other players to your party/friend list/etc. is unimplemented");
+                                            }
+                                            ClientZoneIpcData::InviteReply { .. } => {
+                                                tracing::info!("Replying to other players' invitations is unimplemented");
                                             }
                                             ClientZoneIpcData::Unknown { unk } => {
                                                 tracing::warn!("Unknown Zone packet {:?} recieved ({} bytes), this should be handled!", data.header.op_code, unk.len());

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -218,18 +218,6 @@ pub enum DistanceRange {
     Maximum = 0x2,
 }
 
-// TODO: Possibly relocate this to src/world/common.rs as it's unclear if we'll need this in more places, so it was placed here for now.
-#[binrw]
-#[brw(repr(u16))]
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-pub enum ChatChannel {
-    #[default]
-    Say = 10,
-    Shout = 11,
-    CustomEmote = 28,
-    Yell = 30,
-}
-
 #[binrw]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct EquipDisplayFlag(pub u16);

--- a/src/ipc/chat/chatchannel_common.rs
+++ b/src/ipc/chat/chatchannel_common.rs
@@ -1,0 +1,27 @@
+use binrw::binrw;
+
+#[binrw]
+#[brw(repr = u16)]
+#[derive(Clone, Copy, Debug, Default)]
+pub enum ChatChannelType {
+    #[default]
+    CWLinkshellOrNone = 0,
+    Party = 1,
+    Linkshell = 2,
+    FreeCompany = 3,
+    NoviceNetwork = 4,
+
+    // These technically don't belong here, but if we ever internally represent zone connection chats with ChatChannels (e.g. for multiple worlds, or maybe routing zone chat based on the channel number maybe being a zone id?), these are good to have. These only directly show up as u16s in zone connection chat messages.
+    Say = 10,
+    Shout = 11,
+    CustomEmote = 28,
+    Yell = 30,
+}
+
+#[binrw]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ChatChannel {
+    pub channel_number: u32,
+    pub channel_type: ChatChannelType,
+    pub world_id: u16,
+}

--- a/src/ipc/chat/client/mod.rs
+++ b/src/ipc/chat/client/mod.rs
@@ -22,6 +22,9 @@ pub type ClientChatIpcSegment =
 pub enum ClientChatIpcData {
     SendTellMessage(SendTellMessage),
     SendPartyMessage(SendPartyMessage),
+    GetChannelList {
+        unk: [u8; 8],
+    },
     Unknown {
         #[br(count = size - 32)]
         unk: Vec<u8>,
@@ -52,6 +55,7 @@ mod tests {
         let ipc_types = [
             ClientChatIpcData::SendTellMessage(SendTellMessage::default()),
             ClientChatIpcData::SendPartyMessage(SendPartyMessage::default()),
+            ClientChatIpcData::GetChannelList { unk: [0; 8] },
         ];
 
         for data in &ipc_types {

--- a/src/ipc/chat/mod.rs
+++ b/src/ipc/chat/mod.rs
@@ -3,3 +3,6 @@ pub use server::*;
 
 pub mod client;
 pub use client::*;
+
+pub mod chatchannel_common;
+pub use chatchannel_common::*;

--- a/src/ipc/chat/server/mod.rs
+++ b/src/ipc/chat/server/mod.rs
@@ -27,6 +27,14 @@ pub enum ServerChatIpcData {
     TellMessage(TellMessage),
     PartyMessage(PartyMessage),
     TellNotFoundError(TellNotFoundError),
+    FreeCompanyEvent {
+        // TODO: fill this in
+        unk: [u8; 104],
+    },
+    JoinChannelResult {
+        // TODO: fill this in
+        unk: [u8; 32],
+    },
     Unknown {
         #[br(count = size - 32)]
         unk: Vec<u8>,
@@ -62,6 +70,8 @@ mod tests {
             ServerChatIpcData::TellMessage(TellMessage::default()),
             ServerChatIpcData::PartyMessage(PartyMessage::default()),
             ServerChatIpcData::TellNotFoundError(TellNotFoundError::default()),
+            ServerChatIpcData::FreeCompanyEvent { unk: [0; 104] },
+            ServerChatIpcData::JoinChannelResult { unk: [0; 32] },
         ];
 
         for data in &ipc_types {

--- a/src/ipc/chat/server/party_message.rs
+++ b/src/ipc/chat/server/party_message.rs
@@ -1,11 +1,12 @@
 use binrw::binrw;
 
 use crate::common::{CHAR_NAME_MAX_LENGTH, MESSAGE_MAX_LENGTH, read_string, write_string};
+use crate::ipc::chat::ChatChannel;
 
 #[binrw]
 #[derive(Clone, Debug, Default)]
 pub struct PartyMessage {
-    pub party_chatchannel: u64, // TODO: This will be changed in a future PR to use the proper ChatChannel type (not to be confused with our currently named one)!
+    pub party_chatchannel: ChatChannel,
     pub sender_account_id: u64,
     pub sender_content_id: u64,
 

--- a/src/ipc/zone/client/send_chat_message.rs
+++ b/src/ipc/zone/client/send_chat_message.rs
@@ -1,6 +1,7 @@
 use binrw::binrw;
 
-use crate::common::{ChatChannel, MESSAGE_MAX_LENGTH, Position, read_string, write_string};
+use crate::common::{MESSAGE_MAX_LENGTH, Position, read_string, write_string};
+use crate::ipc::chat::ChatChannelType;
 
 #[binrw]
 #[derive(Clone, Debug, Default)]
@@ -11,7 +12,7 @@ pub struct SendChatMessage {
     pub pos: Position,
     pub rotation: f32,
 
-    pub channel: ChatChannel,
+    pub channel: ChatChannelType,
 
     #[brw(pad_after = 6)] // seems to be junk?
     #[br(count = MESSAGE_MAX_LENGTH)]

--- a/src/ipc/zone/mod.rs
+++ b/src/ipc/zone/mod.rs
@@ -10,5 +10,8 @@ mod social_list;
 mod online_status;
 pub use online_status::*;
 
+mod party_misc;
+pub use party_misc::*;
+
 pub mod server;
 pub use server::*;

--- a/src/ipc/zone/party_misc.rs
+++ b/src/ipc/zone/party_misc.rs
@@ -1,0 +1,85 @@
+use crate::common::{CHAR_NAME_MAX_LENGTH, ObjectId, read_string, write_string};
+use crate::ipc::zone::StatusEffect;
+use binrw::binrw;
+
+#[binrw]
+#[brw(repr = u16)]
+#[derive(Clone, Copy, Debug, Default)]
+pub enum PartyUpdateStatus {
+    #[default]
+    None = 0,
+    JoinParty = 1,
+    PromoteLeader = 2,
+    DisbandingParty = 3,
+    MemberKicked = 4,
+    SelfKicked = 5, // TODO: What is this?
+    MemberLeftParty = 6,
+    SelfLeftParty = 7,
+}
+
+// TODO: This should maybe be moved to a more common place since it encompasses all (?) invite types?
+#[binrw]
+#[brw(repr = u8)]
+#[derive(Clone, Copy, Debug, Default)]
+pub enum InviteType {
+    #[default]
+    Party = 1,
+    FriendList = 2,
+    // TODO: This probably also includes linkshells/cwls, free companies, and maybe novice network, but more captures are needed
+}
+
+#[binrw]
+#[brw(repr = u8)]
+#[derive(Clone, Copy, Debug, Default)]
+pub enum InviteReply {
+    #[default]
+    Declined = 0,
+    Accepted = 1,
+    Cancelled = 2,
+}
+
+#[binrw]
+#[brw(repr = u8)]
+#[derive(Clone, Copy, Debug, Default)]
+pub enum InviteUpdateType {
+    #[default]
+    NewInvite = 1,
+    InviteCancelled = 2,
+    JoinedParty = 3,
+    InviteAccepted = 4,
+    InviteDeclined = 5,
+}
+
+#[binrw]
+#[derive(Clone, Debug, Default)]
+pub struct PartyMemberEntry {
+    #[brw(pad_size_to = CHAR_NAME_MAX_LENGTH)]
+    #[br(count = CHAR_NAME_MAX_LENGTH)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    pub name: String,
+    #[brw(pad_before = 8)] // empty
+    pub account_id: u64,
+    pub content_id: u64,
+    pub actor_id: ObjectId,
+    pub entity_id: ObjectId,
+    pub parent_id: ObjectId,
+    #[brw(pad_after = 2)] // empty
+    pub current_hp: u16,
+    #[brw(pad_after = 2)] //empty
+    pub max_hp: u16,
+    pub current_mp: u16,
+    pub max_mp: u16,
+    pub home_world_id: u16,
+    pub current_zone_id: u16,
+    pub unk1: u8,
+    pub classjob_id: u8,
+    pub unk2: u8,
+    pub classjob_level: u8,
+    #[brw(pad_after = 8)] // empty
+    pub status_effects: [StatusEffect; 30],
+}
+
+impl PartyMemberEntry {
+    pub const SIZE: usize = 456;
+}

--- a/src/ipc/zone/server/chara_info.rs
+++ b/src/ipc/zone/server/chara_info.rs
@@ -1,0 +1,22 @@
+use crate::common::{CHAR_NAME_MAX_LENGTH, read_string, write_string};
+use binrw::binrw;
+
+#[binrw]
+#[derive(Clone, Debug, Default)]
+pub struct CharaInfoFromContentIdsData {
+    #[brw(pad_before = 8)] // empty
+    pub content_id: u64,
+    pub home_world_id: u16,
+    pub current_world_id: u16,
+    pub unk: u16,
+    #[brw(pad_size_to = CHAR_NAME_MAX_LENGTH)]
+    #[br(count = CHAR_NAME_MAX_LENGTH)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    #[brw(pad_after = 2)] // empty
+    pub character_name: String,
+}
+
+impl CharaInfoFromContentIdsData {
+    pub const SIZE: usize = 56;
+}

--- a/src/ipc/zone/server/chat_message.rs
+++ b/src/ipc/zone/server/chat_message.rs
@@ -1,8 +1,8 @@
 use binrw::binrw;
 
-use crate::common::{
-    CHAR_NAME_MAX_LENGTH, ChatChannel, MESSAGE_MAX_LENGTH, read_string, write_string,
-};
+use crate::common::{CHAR_NAME_MAX_LENGTH, MESSAGE_MAX_LENGTH, read_string, write_string};
+
+use crate::ipc::chat::ChatChannelType;
 
 #[binrw]
 #[derive(Clone, Debug, Default)]
@@ -13,7 +13,7 @@ pub struct ChatMessage {
     pub sender_actor_id: u32,
 
     pub sender_world_id: u16,
-    pub channel: ChatChannel,
+    pub channel: ChatChannelType,
 
     #[br(count = CHAR_NAME_MAX_LENGTH)]
     #[bw(pad_size_to = CHAR_NAME_MAX_LENGTH)]

--- a/src/world/common.rs
+++ b/src/world/common.rs
@@ -9,8 +9,8 @@ use std::{
 use tokio::sync::mpsc::Sender;
 
 use crate::{
-    common::{ChatChannel, JumpState, MoveAnimationState, MoveAnimationType, ObjectId, Position},
-    ipc::chat::{SendTellMessage, TellNotFoundError},
+    common::{JumpState, MoveAnimationState, MoveAnimationType, ObjectId, Position},
+    ipc::chat::{ChatChannelType, SendTellMessage, TellNotFoundError},
     ipc::zone::{
         ActionRequest, ActorControl, ActorControlSelf, ActorControlTarget, ClientTrigger,
         Conditions, Config, NpcSpawn, PlayerSpawn, ServerZoneIpcSegment,
@@ -53,7 +53,7 @@ pub struct MessageInfo {
     /// The sender's position in the zone, used for creating a radius around which the message is heard (not yet implemented on Kawari).
     pub sender_position: Position,
     /// The channel the message is intended for (say, shout, yell, custom emote (/em)).
-    pub channel: ChatChannel,
+    pub channel: ChatChannelType,
     /// The chat message itself.
     pub message: String,
 }


### PR DESCRIPTION
This comes in preparation for party support, which is still a WIP, but I'd like to upstream this so I don't have to keep re-basing every time we add new structs or opcodes in the meantime.