### PR TITLE
When the client gracefully disconnects, don't display timeout messages, instead, exit our loops gracefully too.

### DIFF
--- a/src/world/common.rs
+++ b/src/world/common.rs
@@ -107,6 +107,8 @@ pub enum FromServer {
     TellMessageSent(MessageInfo),
     /// We need to inform the sender that the recipient was not found or is offline.
     TellRecipientNotFound(TellNotFoundError),
+    /// We need to tell our chat connection that our zone connection has disconnected.
+    ChatDisconnected(),
 }
 
 #[derive(Debug, Clone)]
@@ -168,7 +170,7 @@ pub enum ToServer {
     /// The player walks through a zone change line.
     EnterZoneJump(ClientId, u32, u32),
     /// The connection disconnected.
-    Disconnected(ClientId),
+    Disconnected(ClientId, u32),
     /// A fatal error occured.
     FatalError(std::io::Error),
     /// Spawn a friendly debug NPC.


### PR DESCRIPTION
Of course, the messages will still display when the client crashes or loses connection, but it doesn't hurt to make our loops exit gracefully when the client is also gracefully leaving.

I also removed the redundant `ToServer::Disconnected` message in the `ClientZoneIpcData::Disconnected` match arm since the end of the zone connection loop sends it anyway. It was causing me some headaches on the party branch, and I didn't notice any obvious regressions with it (I haven't seen zombie players when logging out or force quitting the client).