### PR TITLE
Refactor server.rs to use fewer copy-paste loops

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -115,7 +115,10 @@ pub(crate) fn read_string(byte_stream: Vec<u8>) -> String {
         if let Ok(str) = String::from_utf8(byte_stream.clone()) {
             return str.trim_matches(char::from(0)).to_string(); // trim \0 from the end of strings
         } else {
-            tracing::error!("Found an edge-case where both CStr::from_bytes_until_nul and String::from_utf8 failed: {:#?}", byte_stream.clone());
+            tracing::error!(
+                "Found an edge-case where both CStr::from_bytes_until_nul and String::from_utf8 failed: {:#?}",
+                byte_stream.clone()
+            );
             return String::default();
         }
     };


### PR DESCRIPTION
I wrote a handful of helper functions to reduce copy paste, and they allow for either client network to be informed of whatever messages we need to send.

It might be more ideal to perhaps allow passing in a function to call to handle any desired conditional logic in the loop so we could maybe have even less copy paste here, but I couldn't think of a good way to do it at this moment.