### PR TITLE
Add initial support for parties

### DIFF
--- a/src/ipc/chat/client/send_party_message.rs
+++ b/src/ipc/chat/client/send_party_message.rs
@@ -1,11 +1,12 @@
 use binrw::binrw;
 
 use crate::common::{MESSAGE_MAX_LENGTH, read_string, write_string};
+use crate::ipc::chat::ChatChannel;
 
 #[binrw]
 #[derive(Clone, Debug, Default)]
 pub struct SendPartyMessage {
-    pub party_id: u64,
+    pub chatchannel: ChatChannel,
 
     #[br(count = MESSAGE_MAX_LENGTH)]
     #[bw(pad_size_to = MESSAGE_MAX_LENGTH)]

--- a/src/ipc/zone/client/mod.rs
+++ b/src/ipc/zone/client/mod.rs
@@ -259,8 +259,7 @@ pub enum ClientZoneIpcData {
         unk: [u8; 8], // seems to always be zeroes?
     },
     PartyMemberKick {
-        #[brw(pad_after = 4)]
-        party_index: u32,
+        content_id: u64,
         unk: u16, // Always 0x003F?
 
         #[brw(pad_size_to = CHAR_NAME_MAX_LENGTH)]
@@ -271,10 +270,11 @@ pub enum ClientZoneIpcData {
         character_name: String,
     },
     PartyChangeLeader {
-        #[brw(pad_after = 4)] // empty
-        party_index: u32,
+        /// The actor id of the new leader.
+        content_id: u64,
         unk: u16, // Always 0x003F?
 
+        /// The name of the new leader.
         #[brw(pad_size_to = CHAR_NAME_MAX_LENGTH)]
         #[br(count = CHAR_NAME_MAX_LENGTH)]
         #[br(map = read_string)]
@@ -477,12 +477,12 @@ mod tests {
             ClientZoneIpcData::PartyLeave { unk: [0; 8] },
             ClientZoneIpcData::PartyDisband { unk: [0; 8] },
             ClientZoneIpcData::PartyMemberKick {
-                party_index: 0,
+                content_id: 0,
                 unk: 0,
                 character_name: "".to_string(),
             },
             ClientZoneIpcData::PartyChangeLeader {
-                party_index: 0,
+                content_id: 0,
                 unk: 0,
                 character_name: "".to_string(),
             },

--- a/src/ipc/zone/party_misc.rs
+++ b/src/ipc/zone/party_misc.rs
@@ -4,7 +4,7 @@ use binrw::binrw;
 
 #[binrw]
 #[brw(repr = u16)]
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum PartyUpdateStatus {
     #[default]
     None = 0,
@@ -15,12 +15,16 @@ pub enum PartyUpdateStatus {
     SelfKicked = 5, // TODO: What is this?
     MemberLeftParty = 6,
     SelfLeftParty = 7,
+    MemberChangedZones = 8,
+    Unknown = 9, // TODO: This hasn't been observed yet, but it's included for completeness in case it does exist.
+    MemberWentOffline = 0xA,
+    MemberReturned = 0xB,
 }
 
 // TODO: This should maybe be moved to a more common place since it encompasses all (?) invite types?
 #[binrw]
 #[brw(repr = u8)]
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum InviteType {
     #[default]
     Party = 1,
@@ -30,7 +34,7 @@ pub enum InviteType {
 
 #[binrw]
 #[brw(repr = u8)]
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum InviteReply {
     #[default]
     Declined = 0,
@@ -64,10 +68,8 @@ pub struct PartyMemberEntry {
     pub actor_id: ObjectId,
     pub entity_id: ObjectId,
     pub parent_id: ObjectId,
-    #[brw(pad_after = 2)] // empty
-    pub current_hp: u16,
-    #[brw(pad_after = 2)] //empty
-    pub max_hp: u16,
+    pub current_hp: u32,
+    pub max_hp: u32,
     pub current_mp: u16,
     pub max_mp: u16,
     pub home_world_id: u16,
@@ -82,4 +84,5 @@ pub struct PartyMemberEntry {
 
 impl PartyMemberEntry {
     pub const SIZE: usize = 456;
+    pub const NUM_ENTRIES: usize = 8;
 }

--- a/src/ipc/zone/server/mod.rs
+++ b/src/ipc/zone/server/mod.rs
@@ -515,8 +515,8 @@ pub enum ServerZoneIpcData {
         target_name: String,
     },
     PartyList {
-        #[br(count = 8)]
-        #[bw(pad_size_to = 8 * PartyMemberEntry::SIZE)]
+        #[br(count = PartyMemberEntry::NUM_ENTRIES)]
+        #[bw(pad_size_to = PartyMemberEntry::NUM_ENTRIES * PartyMemberEntry::SIZE)]
         members: Vec<PartyMemberEntry>,
         party_id: u64,
         party_chatchannel: ChatChannel,
@@ -823,7 +823,7 @@ mod tests {
                 target_name: "".to_string(),
             },
             ServerZoneIpcData::PartyList {
-                members: vec![PartyMemberEntry::default(); 8],
+                members: vec![PartyMemberEntry::default(); PartyMemberEntry::NUM_ENTRIES],
                 party_id: 0,
                 party_chatchannel: ChatChannel::default(),
                 leader_index: 0,

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -17,16 +17,19 @@ use crate::{
     },
     config::get_config,
     ipc::{
-        chat::TellNotFoundError,
+        chat::{PartyMessage, TellNotFoundError},
         zone::{
             ActorControl, ActorControlCategory, ActorControlSelf, ActorControlTarget,
             BattleNpcSubKind, ClientTriggerCommand, CommonSpawn, Conditions, NpcSpawn, ObjectKind,
-            PlayerSpawn, ServerZoneIpcData, ServerZoneIpcSegment,
+            OnlineStatus, OnlineStatusMask, PartyMemberEntry, PartyUpdateStatus, PlayerEntry,
+            PlayerSpawn, ServerZoneIpcData, ServerZoneIpcSegment, SocialListRequestType,
+            SocialListUIFlags,
         },
     },
     opcodes::ServerZoneIpcType,
     packet::{IpcSegmentHeader, PacketSegment, SegmentData, SegmentType, ServerIpcSegmentHeader},
     world::MessageInfo,
+    world::common::PartyUpdateTargets,
 };
 
 use super::{Actor, ClientHandle, ClientId, FromServer, Navmesh, ToServer, Zone, lua::LuaZone};
@@ -229,14 +232,84 @@ impl WorldServer {
     }
 }
 
+// TODO: Probably move party-related structs into their own file?
+#[derive(Clone, Debug)]
+struct PartyMember {
+    pub actor_id: ObjectId,
+    pub zone_client_id: ClientId,
+    pub chat_client_id: ClientId,
+    pub content_id: u64,
+    pub account_id: u64,
+    pub world_id: u16,
+    pub name: String,
+}
+
+impl Default for PartyMember {
+    fn default() -> Self {
+        Self {
+            actor_id: INVALID_OBJECT_ID,
+            zone_client_id: ClientId::default(),
+            chat_client_id: ClientId::default(),
+            content_id: 0,
+            account_id: 0,
+            world_id: 0,
+            name: String::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Party {
+    members: [PartyMember; PartyMemberEntry::NUM_ENTRIES],
+    leader_id: u32,
+    chatchannel_id: u32, // There's no reason to store a full u64/ChatChannel here, as it's created properly in the chat connection!
+}
+
+impl Party {
+    pub fn get_member_count(&self) -> usize {
+        self.members
+            .iter()
+            .filter(|x| x.actor_id != INVALID_OBJECT_ID)
+            .count()
+    }
+
+    pub fn remove_member(&mut self, member_to_remove: u32) {
+        for member in self.members.iter_mut() {
+            if member.actor_id.0 == member_to_remove {
+                *member = PartyMember::default();
+                break;
+            }
+        }
+    }
+
+    pub fn get_member_by_content_id(&self, content_id: u64) -> Option<PartyMember> {
+        for member in &self.members {
+            if member.content_id == content_id {
+                return Some(member.clone());
+            }
+        }
+        None
+    }
+    pub fn get_member_by_actor_id(&self, actor_id: u32) -> Option<PartyMember> {
+        for member in &self.members {
+            if member.actor_id.0 == actor_id {
+                return Some(member.clone());
+            }
+        }
+        None
+    }
+}
+
 #[derive(Default, Debug)]
 struct NetworkState {
     to_remove: Vec<ClientId>,
+    to_remove_chat: Vec<ClientId>,
     clients: HashMap<ClientId, (ClientHandle, ClientState)>,
     chat_clients: HashMap<ClientId, (ClientHandle, ClientState)>,
+    parties: HashMap<u64, Party>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum DestinationNetwork {
     ZoneClients,
     ChatClients,
@@ -344,12 +417,92 @@ impl NetworkState {
 
             if handle.actor_id == actor_id {
                 if handle.send(message).is_err() {
-                    self.to_remove.push(id);
+                    if destination == DestinationNetwork::ZoneClients {
+                        self.to_remove.push(id);
+                    } else {
+                        self.to_remove_chat.push(id);
+                    }
                 }
                 break;
             }
         }
     }
+
+    fn send_to_party(
+        &mut self,
+        party_id: u64,
+        from_actor_id: Option<u32>,
+        message: FromServer,
+        destination: DestinationNetwork,
+    ) {
+        let Some(party) = self.parties.get(&party_id) else {
+            return;
+        };
+
+        for member in &party.members {
+            // Skip offline or otherwise non-existent members
+            if member.actor_id == INVALID_OBJECT_ID || member.zone_client_id == ClientId::default()
+            {
+                continue;
+            }
+
+            // Skip a desired party member if needed.
+            if let Some(from_actor_id) = from_actor_id
+                && from_actor_id == member.actor_id.0
+            {
+                continue;
+            }
+
+            match destination {
+                DestinationNetwork::ZoneClients => {
+                    let handle = &mut self.clients.get_mut(&member.zone_client_id).unwrap().0;
+                    if handle.send(message.clone()).is_err() {
+                        self.to_remove.push(member.zone_client_id);
+                    }
+                }
+                DestinationNetwork::ChatClients => {
+                    let handle = &mut self.chat_clients.get_mut(&member.chat_client_id).unwrap().0;
+                    if handle.send(message.clone()).is_err() {
+                        self.to_remove_chat.push(member.chat_client_id);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn build_party_list(party: &Party, data: &WorldServer) -> Vec<PartyMemberEntry> {
+    let mut party_list = Vec::<PartyMemberEntry>::new();
+
+    for instance in data.instances.values() {
+        for (id, actor) in &instance.actors {
+            let spawn = match actor {
+                NetworkedActor::Player(spawn) => spawn,
+                _ => continue,
+            };
+            for member in &party.members {
+                if member.actor_id == *id {
+                    party_list.push(PartyMemberEntry {
+                        account_id: spawn.account_id,
+                        content_id: spawn.content_id,
+                        name: spawn.common.name.clone(),
+                        actor_id: *id,
+                        classjob_id: spawn.common.class_job,
+                        classjob_level: spawn.common.level,
+                        current_hp: spawn.common.hp_curr,
+                        max_hp: spawn.common.hp_max,
+                        current_mp: spawn.common.mp_curr,
+                        max_mp: spawn.common.mp_max,
+                        current_zone_id: instance.zone.id,
+                        ..Default::default()
+                    });
+                    break;
+                }
+            }
+        }
+    }
+
+    party_list
 }
 
 fn do_change_zone(
@@ -1562,7 +1715,6 @@ pub async fn server_main_loop(mut recv: Receiver<ToServer>) -> Result<(), std::i
             }
             ToServer::Disconnected(from_id, from_actor_id) => {
                 let mut network = network.lock().unwrap();
-
                 network.to_remove.push(from_id);
 
                 // Tell our sibling chat connection that it's time to go too.
@@ -1697,6 +1849,748 @@ pub async fn server_main_loop(mut recv: Receiver<ToServer>) -> Result<(), std::i
                     );
                 }
             }
+
+            ToServer::InvitePlayerToParty(from_actor_id, content_id, character_name) => {
+                // TODO: Return an error when the target player's already in a party or offline somehow
+                let mut network = network.lock().unwrap();
+                let data = data.lock().unwrap();
+
+                // First pull up some info about the sender, as tell packets require it
+                let Some(sender_instance) = data.find_actor_instance(from_actor_id.0) else {
+                    tracing::error!(
+                        "ToServer::InvitePlayerToParty: Unable to find the sender! What happened?"
+                    );
+                    continue;
+                };
+
+                let mut sender_name = "".to_string();
+                let mut sender_account_id = 0;
+                let mut sender_content_id = 0;
+
+                for (id, actor) in &sender_instance.actors {
+                    if id.0 == from_actor_id.0 {
+                        let Some(spawn) = actor.get_player_spawn() else {
+                            panic!("Why are we trying to get the PlayerSpawn of an NPC?");
+                        };
+
+                        sender_name = spawn.common.name.clone();
+                        sender_account_id = spawn.account_id;
+                        sender_content_id = spawn.content_id;
+                        break;
+                    }
+                }
+
+                // If the sender wasn't found in the instance we already found them to be in, reality has apparently broken
+                assert!(sender_content_id != 0);
+
+                let mut recipient_actor_id = INVALID_OBJECT_ID;
+
+                // Second, look up the recipient by name, since that and their content id are all we're given by the sending client.
+                // Since we don't implement multiple worlds, the world id isn't useful for anything here.
+                'outer: for instance in data.instances.values() {
+                    for (id, actor) in &instance.actors {
+                        if let NetworkedActor::Player(spawn) = actor {
+                            if spawn.content_id == content_id || spawn.common.name == character_name
+                            {
+                                recipient_actor_id = *id;
+                                break 'outer;
+                            }
+                        }
+                    }
+                }
+
+                let mut already_in_party = false;
+
+                // Next, see if the recipient is already in a party, and let the sender know if they are...
+                'outer: for party in network.parties.values() {
+                    for member in &party.members {
+                        if member.actor_id == recipient_actor_id {
+                            already_in_party = true;
+                            break 'outer;
+                        }
+                    }
+                }
+
+                if !already_in_party {
+                    // Finally, if the recipient is online, fetch their handle from the network and send them the message!
+                    if recipient_actor_id != INVALID_OBJECT_ID {
+                        for (id, (handle, _)) in &mut network.clients {
+                            if handle.actor_id == recipient_actor_id.0 {
+                                let msg = FromServer::PartyInvite(
+                                    sender_account_id,
+                                    sender_content_id,
+                                    sender_name,
+                                );
+                                if handle.send(msg.clone()).is_err() {
+                                    to_remove.push(*id);
+                                }
+                                break;
+                            }
+                        }
+                    } else {
+                        // TODO: Else, if the recipient is offline, inform the sender.
+                        tracing::error!(
+                            "InvitePlayerToParty: The recipient is offline! What happened?"
+                        );
+                    }
+                } else {
+                    let msg = FromServer::CharacterAlreadyInParty();
+                    network.send_to_by_actor_id(
+                        from_actor_id.0,
+                        msg,
+                        DestinationNetwork::ZoneClients,
+                    );
+                }
+            }
+            ToServer::InvitationResponse(
+                from_id,
+                from_account_id,
+                from_content_id,
+                from_name,
+                sender_content_id,
+                invite_type,
+                response,
+            ) => {
+                let mut network = network.lock().unwrap();
+                let data = data.lock().unwrap();
+
+                // Look up the invite sender and tell them the response.
+                let mut recipient_actor_id = INVALID_OBJECT_ID;
+
+                // Second, look up the recipient (the original invite sender) by content id, since that is all we're given by the sending client.
+                'outer: for instance in data.instances.values() {
+                    for (id, actor) in &instance.actors {
+                        let Some(spawn) = actor.get_player_spawn() else {
+                            panic!("Why are we looking up the PlayerSpawn of an NPC?");
+                        };
+                        if spawn.content_id == sender_content_id {
+                            recipient_actor_id = *id;
+                            break 'outer;
+                        }
+                    }
+                }
+
+                if recipient_actor_id != INVALID_OBJECT_ID {
+                    for (id, (handle, _)) in &mut network.clients {
+                        // Tell the invite sender about the invite result
+                        if handle.actor_id == recipient_actor_id.0
+                            && recipient_actor_id != INVALID_OBJECT_ID
+                        {
+                            let msg = FromServer::InvitationResult(
+                                from_account_id,
+                                from_content_id,
+                                from_name.clone(),
+                                invite_type,
+                                response,
+                            );
+                            if handle.send(msg.clone()).is_err() {
+                                to_remove.push(*id);
+                            }
+                        }
+                        // Tell the client who just responded to the sender's invite to wait for further instructions
+                        if *id == from_id {
+                            let msg = FromServer::InvitationReplyResult(
+                                from_content_id,
+                                from_name.clone(),
+                                invite_type,
+                                response,
+                            );
+                            if handle.send(msg.clone()).is_err() {
+                                to_remove.push(*id);
+                            }
+                        }
+                    }
+                }
+            }
+            ToServer::RequestSocialList(from_id, from_actor_id, from_party_id, request) => {
+                let mut network = network.lock().unwrap();
+                let data = data.lock().unwrap();
+                let mut entries = vec![PlayerEntry::default(); 10];
+
+                match &request.request_type {
+                    SocialListRequestType::Party => {
+                        if from_party_id != 0 {
+                            let leader_actor_id = network.parties[&from_party_id].leader_id;
+                            let mut index: usize = 0;
+                            for member in &network.parties[&from_party_id].members {
+                                let Some(instance) = data.find_actor_instance(member.actor_id.0)
+                                else {
+                                    continue;
+                                };
+
+                                for (id, actor) in &instance.actors {
+                                    if *id == member.actor_id {
+                                        let Some(spawn) = actor.get_player_spawn() else {
+                                            panic!(
+                                                "Why are we trying to get the PlayerSpawn of an NPC?"
+                                            );
+                                        };
+
+                                        if member.zone_client_id != ClientId::default() {
+                                            let mut online_status_mask =
+                                                OnlineStatusMask::default();
+                                            //TODO: account for people being offline
+                                            online_status_mask.set_status(OnlineStatus::Online);
+                                            online_status_mask
+                                                .set_status(OnlineStatus::PartyMember);
+                                            if member.actor_id.0 == leader_actor_id {
+                                                online_status_mask
+                                                    .set_status(OnlineStatus::PartyLeader);
+                                            }
+                                            entries[index].online_status_mask = online_status_mask;
+                                            entries[index].classjob_id = spawn.common.class_job;
+                                            entries[index].classjob_level = spawn.common.level;
+                                            entries[index].zone_id = instance.zone.id;
+                                        }
+
+                                        entries[index].content_id = spawn.content_id;
+                                        entries[index].current_world_id = spawn.home_world_id;
+                                        entries[index].name = spawn.common.name.clone();
+                                        entries[index].ui_flags =
+                                            SocialListUIFlags::ENABLE_CONTEXT_MENU;
+
+                                        index += 1;
+                                        break;
+                                    }
+                                }
+                            }
+                        } else {
+                            let Some(instance) = data.find_actor_instance(from_actor_id) else {
+                                continue;
+                            };
+
+                            for (id, actor) in &instance.actors {
+                                if id.0 == from_actor_id {
+                                    let Some(spawn) = actor.get_player_spawn() else {
+                                        panic!(
+                                            "Why are we trying to get the PlayerSpawn of an NPC?"
+                                        );
+                                    };
+
+                                    // TODO: Probably start with a cached status from elsewhere?
+                                    let mut online_status_mask = OnlineStatusMask::default();
+                                    online_status_mask.set_status(OnlineStatus::Online);
+
+                                    entries[0].content_id = spawn.content_id;
+                                    entries[0].current_world_id = spawn.home_world_id;
+                                    entries[0].name = spawn.common.name.clone();
+                                    entries[0].ui_flags = SocialListUIFlags::ENABLE_CONTEXT_MENU;
+                                    entries[0].online_status_mask = online_status_mask;
+                                    entries[0].classjob_id = spawn.common.class_job;
+                                    entries[0].classjob_level = spawn.common.level;
+                                    entries[0].zone_id = instance.zone.id;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    SocialListRequestType::Friends => {
+                        tracing::warn!(
+                            "SocialListRequestType was Friends! This is not yet implemented!"
+                        );
+                    }
+                }
+
+                let msg =
+                    FromServer::SocialListResponse(request.request_type, request.count, entries);
+                network.send_to(from_id, msg, DestinationNetwork::ZoneClients);
+            }
+            ToServer::AddPartyMember(party_id, leader_actor_id, new_member_content_id) => {
+                let mut network = network.lock().unwrap();
+                let data = data.lock().unwrap();
+                let mut party_id = party_id;
+
+                // This client is creating a party.
+                if party_id == 0 {
+                    // TODO: We should probably generate these differently so there are no potential collisions.
+                    party_id = fastrand::u64(..);
+                    let chatchannel_id = fastrand::u32(..);
+                    let party = network.parties.entry(party_id).or_default();
+                    party.chatchannel_id = chatchannel_id;
+                    party.leader_id = leader_actor_id;
+                    party.members[0].actor_id = ObjectId(leader_actor_id);
+                }
+
+                if let Some(party) = network.parties.get(&party_id) {
+                    let chatchannel_id = network.parties[&party_id].chatchannel_id;
+                    let mut party = party.members.clone();
+
+                    let mut party_list = Vec::<PartyMemberEntry>::new();
+
+                    let mut execute_account_id = 0;
+                    let mut execute_content_id = 0;
+                    let mut execute_name = String::default();
+                    let mut target_account_id = 0;
+                    let mut target_content_id = 0;
+                    let mut target_name = String::default();
+
+                    // TODO: This can probably be simplified/the logic can probably be adjusted, need to think more on this
+                    for instance in data.instances.values() {
+                        for (id, actor) in &instance.actors {
+                            let Some(spawn) = actor.get_player_spawn() else {
+                                continue;
+                            };
+
+                            if spawn.content_id == new_member_content_id {
+                                // Find the first open member slot.
+                                let Some(free_index) =
+                                    party.iter().position(|x| x.actor_id == INVALID_OBJECT_ID)
+                                else {
+                                    // TODO: See if we can gracefully exit from here without a panic
+                                    panic!(
+                                        "Tried to add a party member to a full party! What happened? {party:#?}"
+                                    );
+                                };
+                                party[free_index].actor_id = *id;
+                                target_account_id = spawn.account_id;
+                                target_content_id = spawn.content_id;
+                                target_name = spawn.common.name.clone();
+                            }
+
+                            if id.0 == leader_actor_id {
+                                execute_account_id = spawn.account_id;
+                                execute_content_id = spawn.content_id;
+                                execute_name = spawn.common.name.clone();
+                            }
+
+                            for member in &mut party {
+                                if member.actor_id == *id {
+                                    member.account_id = spawn.account_id;
+                                    member.content_id = spawn.content_id;
+                                    member.name = spawn.common.name.clone();
+
+                                    party_list.push(PartyMemberEntry {
+                                        account_id: spawn.account_id,
+                                        content_id: spawn.content_id,
+                                        name: spawn.common.name.clone(),
+                                        actor_id: *id,
+                                        classjob_id: spawn.common.class_job,
+                                        classjob_level: spawn.common.level,
+                                        current_hp: spawn.common.hp_curr,
+                                        max_hp: spawn.common.hp_max,
+                                        current_mp: spawn.common.mp_curr,
+                                        max_mp: spawn.common.mp_max,
+                                        current_zone_id: instance.zone.id,
+                                        ..Default::default()
+                                    });
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    assert!(
+                        !party_list.is_empty() && party_list.len() <= PartyMemberEntry::NUM_ENTRIES
+                    );
+
+                    let update_status = PartyUpdateStatus::JoinParty;
+
+                    let msg = FromServer::PartyUpdate(
+                        PartyUpdateTargets {
+                            execute_account_id,
+                            execute_content_id,
+                            execute_name: execute_name.clone(),
+                            target_account_id,
+                            target_content_id,
+                            target_name: target_name.clone(),
+                        },
+                        update_status,
+                        Some((
+                            party_id,
+                            chatchannel_id,
+                            ObjectId(leader_actor_id),
+                            party_list.clone(),
+                        )),
+                    );
+
+                    // Next, tell everyone in the party someone joined (including the joining player themself).
+                    // Also cache their client ids to speed up sending future replies.
+                    for (id, (handle, _)) in &mut network.clients {
+                        for member in &mut party {
+                            if member.actor_id.0 == handle.actor_id {
+                                member.zone_client_id = *id;
+                                if handle.send(msg.clone()).is_err() {
+                                    to_remove.push(*id);
+                                }
+                            }
+                        }
+                    }
+
+                    let msg = FromServer::SetPartyChatChannel(chatchannel_id);
+
+                    // Finally, tell their chat connections they're now in a party.
+                    // Also cache their client ids to speed up sending future replies.
+                    for (id, (handle, _)) in &mut network.chat_clients {
+                        for member in &mut party {
+                            if member.actor_id.0 == handle.actor_id {
+                                member.chat_client_id = *id;
+                                if handle.send(msg.clone()).is_err() {
+                                    to_remove.push(*id);
+                                }
+                            }
+                        }
+                    }
+
+                    network.parties.get_mut(&party_id).unwrap().members = party; // now we can give the clone back after all that nonsense
+                } else {
+                    tracing::error!(
+                        "AddPartyMember: Party id wasn't in the hashmap! What happened?"
+                    );
+                }
+            }
+            ToServer::PartyMessageSent(from_actor_id, message_info) => {
+                let mut network = network.lock().unwrap();
+
+                let mut sender = PartyMember::default();
+                let mut party_id = 0;
+
+                // We need some info about the sender since our chat connection doesn't provide it.
+                for (id, party) in &network.parties {
+                    if party.chatchannel_id == message_info.chatchannel.channel_number {
+                        party_id = *id;
+                        for member in &party.members {
+                            if member.actor_id.0 == from_actor_id {
+                                sender = member.clone();
+                            }
+                        }
+                    }
+                }
+
+                assert!(party_id != 0 && sender.actor_id != INVALID_OBJECT_ID);
+
+                let party_message = PartyMessage {
+                    party_chatchannel: message_info.chatchannel,
+                    sender_account_id: sender.account_id,
+                    sender_content_id: sender.content_id,
+                    sender_world_id: sender.world_id,
+                    sender_actor_id: sender.actor_id.0,
+                    sender_name: sender.name.clone(),
+                    message: message_info.message,
+                };
+                let msg = FromServer::PartyMessageSent(party_message);
+
+                // Skip the original sender to avoid echoing messages
+                network.send_to_party(
+                    party_id,
+                    Some(from_actor_id),
+                    msg,
+                    DestinationNetwork::ChatClients,
+                );
+            }
+            ToServer::PartyMemberChangedAreas(
+                party_id,
+                execute_account_id,
+                execute_content_id,
+                execute_name,
+            ) => {
+                let mut network = network.lock().unwrap();
+                let data = data.lock().unwrap();
+                let party = network.parties.get_mut(&party_id).unwrap();
+
+                let party_list = build_party_list(party, &data);
+
+                let msg = FromServer::PartyUpdate(
+                    PartyUpdateTargets {
+                        execute_account_id,
+                        execute_content_id,
+                        execute_name: execute_name.clone(),
+                        target_account_id: 0,
+                        target_content_id: 0,
+                        target_name: String::default(),
+                    },
+                    PartyUpdateStatus::MemberChangedZones,
+                    Some((
+                        party_id,
+                        party.chatchannel_id,
+                        ObjectId(party.leader_id),
+                        party_list,
+                    )),
+                );
+
+                // Finally, tell everyone in the party about the update.
+                network.send_to_party(party_id, None, msg, DestinationNetwork::ZoneClients);
+            }
+            ToServer::PartyChangeLeader(
+                party_id,
+                execute_account_id,
+                execute_content_id,
+                execute_name,
+                target_content_id,
+                target_name,
+            ) => {
+                let mut network = network.lock().unwrap();
+
+                if !network.parties.contains_key(&party_id) {
+                    panic!("Why are we trying to do party operations on an invalid party?");
+                }
+
+                let data = data.lock().unwrap();
+                let target_account_id;
+                {
+                    let party = &mut network.parties.get_mut(&party_id).unwrap();
+                    let Some(member) = party.get_member_by_content_id(target_content_id) else {
+                        continue;
+                    };
+                    party.leader_id = member.actor_id.0;
+                    target_account_id = member.account_id;
+                }
+
+                let party = &network.parties.get(&party_id).unwrap();
+
+                let party_list = build_party_list(party, &data);
+
+                let msg = FromServer::PartyUpdate(
+                    PartyUpdateTargets {
+                        execute_account_id,
+                        execute_content_id,
+                        execute_name: execute_name.clone(),
+                        target_account_id,
+                        target_content_id,
+                        target_name: target_name.clone(),
+                    },
+                    PartyUpdateStatus::PromoteLeader,
+                    Some((
+                        party_id,
+                        party.chatchannel_id,
+                        ObjectId(party.leader_id),
+                        party_list,
+                    )),
+                );
+
+                // Finally, tell everyone in the party about the update.
+                network.send_to_party(party_id, None, msg, DestinationNetwork::ZoneClients);
+            }
+            ToServer::PartyMemberLeft(
+                party_id,
+                execute_account_id,
+                execute_content_id,
+                execute_actor_id,
+                execute_name,
+            ) => {
+                let mut network = network.lock().unwrap();
+                let data = data.lock().unwrap();
+                let party_list;
+                let leaving_zone_client_id;
+                let leaving_chat_client_id;
+                let chatchannel_id;
+                let leader_id;
+                let member_count;
+                {
+                    let Some(party) = network.parties.get_mut(&party_id) else {
+                        continue;
+                    };
+                    chatchannel_id = party.chatchannel_id;
+                    leader_id = party.leader_id;
+
+                    // Construct the party list we're sending back to the clients in this party.
+                    leaving_zone_client_id = party
+                        .get_member_by_actor_id(execute_actor_id)
+                        .unwrap()
+                        .zone_client_id;
+                    leaving_chat_client_id = party
+                        .get_member_by_actor_id(execute_actor_id)
+                        .unwrap()
+                        .chat_client_id;
+
+                    party.remove_member(execute_actor_id);
+                    member_count = party.get_member_count();
+                    party_list = build_party_list(party, &data);
+                }
+
+                let update_status;
+                let party_info;
+
+                // TODO: Instead of auto-disbanding when the leader goes offline, promote someene instead!
+                if member_count < 2 || execute_actor_id == leader_id {
+                    update_status = PartyUpdateStatus::DisbandingParty;
+                    party_info = None;
+                } else {
+                    update_status = PartyUpdateStatus::MemberLeftParty;
+                    party_info = Some((party_id, chatchannel_id, ObjectId(leader_id), party_list));
+                }
+
+                let msg = FromServer::PartyUpdate(
+                    PartyUpdateTargets {
+                        execute_account_id,
+                        execute_content_id,
+                        execute_name: execute_name.clone(),
+                        target_account_id: 0,
+                        target_content_id: 0,
+                        target_name: String::default(),
+                    },
+                    update_status,
+                    party_info,
+                );
+
+                let leaver_msg = FromServer::PartyUpdate(
+                    PartyUpdateTargets {
+                        execute_account_id,
+                        execute_content_id,
+                        execute_name: execute_name.clone(),
+                        target_account_id: 0,
+                        target_content_id: 0,
+                        target_name: String::default(),
+                    },
+                    update_status,
+                    None,
+                );
+
+                // Tell everyone in the party about the update.
+                network.send_to_party(party_id, None, msg, DestinationNetwork::ZoneClients);
+
+                // Tell the leaver that they're not in the party anymore.
+                network.send_to(
+                    leaving_zone_client_id,
+                    leaver_msg,
+                    DestinationNetwork::ZoneClients,
+                );
+                network.send_to(
+                    leaving_chat_client_id,
+                    FromServer::SetPartyChatChannel(0),
+                    DestinationNetwork::ChatClients,
+                );
+
+                // Clean up the party on our side, if necessary.
+                // TODO: Instead of auto-disbanding when the leader goes offline, promote someene instead!
+                if member_count < 2 || execute_actor_id == leader_id {
+                    // Tell their chat connections they're no longer in a party.
+                    network.send_to_party(
+                        party_id,
+                        None,
+                        FromServer::SetPartyChatChannel(0),
+                        DestinationNetwork::ChatClients,
+                    );
+                    network.parties.remove(&party_id);
+                }
+            }
+            ToServer::PartyDisband(
+                party_id,
+                execute_account_id,
+                execute_content_id,
+                execute_name,
+            ) => {
+                let mut network = network.lock().unwrap();
+
+                let msg = FromServer::PartyUpdate(
+                    PartyUpdateTargets {
+                        execute_account_id,
+                        execute_content_id,
+                        execute_name: execute_name.clone(),
+                        target_account_id: 0,
+                        target_content_id: 0,
+                        target_name: String::default(),
+                    },
+                    PartyUpdateStatus::DisbandingParty,
+                    None,
+                );
+
+                // Finally, tell everyone in the party about the update.
+                network.send_to_party(party_id, None, msg, DestinationNetwork::ZoneClients);
+
+                // Tell their chat connections they're no longer in a party.
+                network.send_to_party(
+                    party_id,
+                    None,
+                    FromServer::SetPartyChatChannel(0),
+                    DestinationNetwork::ChatClients,
+                );
+
+                // We don't need to keep track of this party anymore.
+                network.parties.remove(&party_id);
+            }
+            ToServer::PartyMemberKick(
+                party_id,
+                execute_account_id,
+                execute_content_id,
+                execute_name,
+                target_content_id,
+                target_name,
+            ) => {
+                let mut network = network.lock().unwrap();
+                let data = data.lock().unwrap();
+                let party = network.parties.get_mut(&party_id).unwrap();
+
+                let Some(member) = party.get_member_by_content_id(target_content_id) else {
+                    continue;
+                };
+                party.remove_member(member.actor_id.0);
+
+                // Construct the party list we're sending back to the clients in this party.
+                let party_list = build_party_list(party, &data);
+
+                let update_status;
+                let party_info;
+                let member_count = party.get_member_count();
+                if member_count < 2 {
+                    update_status = PartyUpdateStatus::DisbandingParty;
+                    party_info = None;
+                } else {
+                    update_status = PartyUpdateStatus::MemberKicked;
+                    party_info = Some((
+                        party_id,
+                        party.chatchannel_id,
+                        ObjectId(party.leader_id),
+                        party_list,
+                    ));
+                }
+
+                let msg = FromServer::PartyUpdate(
+                    PartyUpdateTargets {
+                        execute_account_id,
+                        execute_content_id,
+                        execute_name: execute_name.clone(),
+                        target_account_id: member.account_id,
+                        target_content_id,
+                        target_name: target_name.clone(),
+                    },
+                    update_status,
+                    party_info,
+                );
+
+                let leaver_msg = FromServer::PartyUpdate(
+                    PartyUpdateTargets {
+                        execute_account_id,
+                        execute_content_id,
+                        execute_name: execute_name.clone(),
+                        target_account_id: 0,
+                        target_content_id: 0,
+                        target_name: String::default(),
+                    },
+                    update_status,
+                    None,
+                );
+
+                // Tell everyone in the party about the update.
+                network.send_to_party(party_id, None, msg, DestinationNetwork::ZoneClients);
+
+                // Tell the leaver that they're not in the party anymore, including their chat connection.
+                network.send_to(
+                    member.zone_client_id,
+                    leaver_msg,
+                    DestinationNetwork::ZoneClients,
+                );
+                network.send_to(
+                    member.chat_client_id,
+                    FromServer::SetPartyChatChannel(0),
+                    DestinationNetwork::ChatClients,
+                );
+
+                // Clean up the party on our side, if necessary.
+                if member_count < 2 {
+                    // Tell their chat connections they're no longer in a party.
+                    network.send_to_party(
+                        party_id,
+                        None,
+                        FromServer::SetPartyChatChannel(0),
+                        DestinationNetwork::ChatClients,
+                    );
+                    network.parties.remove(&party_id);
+                }
+            }
+            ToServer::ChatDisconnected(from_id) => {
+                let mut network = network.lock().unwrap();
+                network.to_remove_chat.push(from_id);
+            }
             ToServer::FatalError(err) => return Err(err),
         }
 
@@ -1725,6 +2619,10 @@ pub async fn server_main_loop(mut recv: Receiver<ToServer>) -> Result<(), std::i
                 }
 
                 network.clients.remove(&remove_id);
+            }
+
+            for remove_id in network.to_remove_chat.clone() {
+                network.chat_clients.remove(&remove_id);
             }
         }
     }

--- a/src/world/zone_connection.rs
+++ b/src/world/zone_connection.rs
@@ -26,9 +26,12 @@ use crate::{
         TRIPLE_TRIAD_CARDS_BITMASK_SIZE, UNLOCK_BITMASK_SIZE,
     },
     inventory::{BuyBackList, ContainerType, Inventory, Item, Storage},
+    ipc::chat::{ChatChannel, ChatChannelType},
     ipc::zone::{
-        ActionKind, ChatMessage, DisplayFlag, EventType, InitZoneFlags, OnlineStatus, PlayerSpawn,
-        SceneFlags, ServerNoticeFlags, ServerNoticeMessage,
+        ActionKind, ChatMessage, DisplayFlag, EventType, InitZoneFlags, InviteReply, InviteType,
+        InviteUpdateType, OnlineStatus, OnlineStatusMask, PartyMemberEntry, PartyUpdateStatus,
+        PlayerEntry, PlayerSpawn, SceneFlags, ServerNoticeFlags, ServerNoticeMessage, SocialList,
+        SocialListRequestType,
         client::{ActionRequest, ClientZoneIpcSegment},
         server::{
             ActionEffect, ActionResult, ActorControl, ActorControlCategory, ActorControlSelf,
@@ -45,6 +48,7 @@ use crate::{
         ScramblerKeyGenerator, SegmentData, SegmentType, ServerIpcSegmentHeader, parse_packet,
         send_keep_alive, send_packet,
     },
+    world::common::PartyUpdateTargets,
 };
 
 use super::{
@@ -168,6 +172,8 @@ pub struct PlayerData {
     pub display_flags: EquipDisplayFlag,
     pub teleport_reason: TeleportReason,
     pub active_minion: u32,
+    /// The player's party id number, used for networking party-related events
+    pub party_id: u64,
 }
 
 /// Various obsfucation-related bits like the seeds and keys for this connection.
@@ -2493,5 +2499,263 @@ impl ZoneConnection {
             let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::PlayerSpawn(spawn));
             self.send_ipc_self(ipc).await;
         }
+    }
+
+    pub async fn received_party_invite(
+        &mut self,
+        sender_account_id: u64,
+        sender_content_id: u64,
+        sender_name: String,
+    ) {
+        let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::InviteUpdate {
+            sender_account_id,
+            sender_content_id,
+            expiration_timestamp: timestamp_secs() + 300, // usually the packet's timestamp + 300, TODO: we might want to keep a timer going somewhere to inform the original sender if it expires due to timeout, does retail do that?
+            world_id: self.config.world_id,
+            invite_type: InviteType::Party,
+            update_type: InviteUpdateType::NewInvite,
+            unk1: 1,
+            sender_name,
+        });
+        self.send_ipc_self(ipc).await;
+    }
+
+    pub async fn send_invite_update(
+        &mut self,
+        from_account_id: u64,
+        from_content_id: u64,
+        from_name: String,
+        invite_type: InviteType,
+        response: InviteReply,
+    ) {
+        let update_type = match response {
+            InviteReply::Accepted => InviteUpdateType::InviteAccepted,
+            InviteReply::Declined => InviteUpdateType::InviteDeclined,
+            InviteReply::Cancelled => InviteUpdateType::InviteCancelled,
+        };
+
+        let response = ServerZoneIpcSegment::new(ServerZoneIpcData::InviteUpdate {
+            sender_content_id: from_content_id,
+            sender_account_id: from_account_id,
+            expiration_timestamp: 0,
+            world_id: self.config.world_id,
+            invite_type,
+            update_type,
+            unk1: 1,
+            sender_name: from_name,
+        });
+        self.send_ipc_self(response).await;
+    }
+
+    /// The player received an invitation response from another player.
+    pub async fn received_invitation_response(
+        &mut self,
+        from_account_id: u64,
+        from_content_id: u64,
+        from_name: String,
+        invite_type: InviteType,
+        response: InviteReply,
+    ) {
+        // only party supported for now
+        if invite_type != InviteType::Party {
+            return;
+        }
+
+        if response == InviteReply::Accepted {
+            self.handle
+                .send(ToServer::AddPartyMember(
+                    self.player_data.party_id,
+                    self.player_data.actor_id,
+                    from_content_id,
+                ))
+                .await;
+        }
+
+        self.send_invite_update(
+            from_account_id,
+            from_content_id,
+            from_name,
+            invite_type,
+            response,
+        )
+        .await;
+    }
+
+    /// The player needs to be informed about the reply they just sent.
+    pub async fn send_invite_reply_result(
+        &mut self,
+        from_content_id: u64,
+        from_name: String,
+        invite_type: InviteType,
+        response: InviteReply,
+    ) {
+        let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::InviteReplyResult {
+            content_id: from_content_id,
+            invite_type,
+            response,
+            unk1: 1,
+            character_name: from_name,
+        });
+        self.send_ipc_self(ipc).await;
+    }
+
+    // A party event happened, so we need to inform our client.
+    pub async fn send_party_update(
+        &mut self,
+        targets: PartyUpdateTargets,
+        update_status: PartyUpdateStatus,
+
+        party_info: Option<(u64, u32, ObjectId, Vec<PartyMemberEntry>)>,
+    ) {
+        if let Some((party_id, chatchannel_id, leader_actor_id, mut party_list)) = party_info {
+            if self.player_data.party_id == 0 {
+                self.player_data.party_id = party_id;
+            }
+
+            let member_count = party_list.len() as u8;
+
+            let Some(leader_index) = party_list
+                .iter()
+                .position(|x: &PartyMemberEntry| x.actor_id == leader_actor_id)
+            else {
+                tracing::error!(
+                    "Unable to determine party leader! What happened? {} {} {} {:#?}",
+                    party_id,
+                    chatchannel_id,
+                    leader_actor_id,
+                    party_list
+                );
+                return;
+            };
+            // Set our OnlineStatusMask to reflect we're now in a party.
+            let mut new_status_mask = OnlineStatusMask::default();
+            new_status_mask.set_status(OnlineStatus::Online);
+            new_status_mask.set_status(OnlineStatus::PartyMember);
+            let mut icon = OnlineStatus::PartyMember;
+            if self.player_data.actor_id == leader_actor_id.0 {
+                new_status_mask.set_status(OnlineStatus::PartyLeader);
+                icon = OnlineStatus::PartyLeader;
+            }
+            self.actor_control(
+                self.player_data.actor_id,
+                ActorControl {
+                    category: ActorControlCategory::SetStatusIcon { icon },
+                },
+            )
+            .await;
+            let ipc =
+                ServerZoneIpcSegment::new(ServerZoneIpcData::SetOnlineStatus(new_status_mask));
+            self.send_ipc_self(ipc).await;
+
+            // We edit the party list to hide information of players not in our zone.
+            for member in party_list.iter_mut() {
+                if (member.actor_id.0 != self.player_data.actor_id
+                    && member.current_zone_id != self.player_data.zone_id)
+                    || (update_status == PartyUpdateStatus::MemberWentOffline
+                        && member.content_id == targets.execute_content_id)
+                {
+                    member.actor_id = ObjectId(0);
+                    member.classjob_id = 0;
+                    member.classjob_level = 0;
+                    member.current_hp = 0;
+                    member.max_hp = 0;
+                    member.current_mp = 0;
+                    member.max_mp = 0;
+                }
+            }
+
+            // Ensure we have only the correct amount of entries. Possibly redundant with binrw, but it doesn't hurt to be safe.
+            party_list.resize(PartyMemberEntry::NUM_ENTRIES, PartyMemberEntry::default());
+
+            let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::PartyList {
+                members: party_list,
+                member_count,
+                leader_index: leader_index as u8,
+                party_id: self.player_data.party_id,
+                party_chatchannel: ChatChannel {
+                    channel_number: chatchannel_id,
+                    channel_type: ChatChannelType::Party,
+                    world_id: self.config.world_id,
+                },
+            });
+
+            self.send_ipc_self(ipc).await;
+        } else {
+            // If there's no data, then we're the one who left.
+            let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::PartyList {
+                members: vec![PartyMemberEntry::default(); PartyMemberEntry::NUM_ENTRIES],
+                member_count: 0,
+                leader_index: 0,
+                party_id: 0,
+                party_chatchannel: ChatChannel {
+                    channel_number: 0,
+                    channel_type: ChatChannelType::Party,
+                    world_id: self.config.world_id,
+                },
+            });
+            self.send_ipc_self(ipc).await;
+
+            // Set our OnlineStatusMask to reflect we're no longer in a party.
+            // TODO: Actually remove the party status once we're storing it in the zoneconnection...
+            let mut new_status_mask = OnlineStatusMask::default();
+            new_status_mask.set_status(OnlineStatus::Online);
+
+            let icon = OnlineStatus::Offline;
+
+            self.actor_control(
+                self.player_data.actor_id,
+                ActorControl {
+                    category: ActorControlCategory::SetStatusIcon { icon },
+                },
+            )
+            .await;
+
+            let ipc =
+                ServerZoneIpcSegment::new(ServerZoneIpcData::SetOnlineStatus(new_status_mask));
+            self.send_ipc_self(ipc).await;
+
+            self.player_data.party_id = 0;
+        }
+
+        // TODO:
+        // after partylist they send playerstats, but we'll skip it for now
+        // after stats they send a second redundant ac SetStatusIcon and UpdateOnlineStatusMask
+
+        let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::PartyUpdate {
+            execute_account_id: targets.execute_account_id,
+            target_account_id: targets.target_account_id,
+            execute_content_id: targets.execute_content_id,
+            target_content_id: targets.target_content_id,
+            update_status,
+            execute_name: targets.execute_name,
+            target_name: targets.target_name,
+            unk1: 0,
+            unk2: 0,
+            unk3: 0,
+        });
+
+        self.send_ipc_self(ipc).await;
+
+        // TODO:
+        // after party update they send the status effect list
+        // after the status effect list they send updateclassinfo
+    }
+
+    pub async fn send_social_list(
+        &mut self,
+        request_type: SocialListRequestType,
+        sequence: u8,
+        entries: Vec<PlayerEntry>,
+    ) {
+        let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::SocialList(SocialList {
+            request_type,
+            sequence,
+            entries,
+        }));
+        self.send_ipc_self(ipc).await;
+    }
+
+    pub fn is_in_party(&self) -> bool {
+        self.player_data.party_id != 0
     }
 }


### PR DESCRIPTION
This has been a long time coming with a number of refactors and probably even more research, but it's finally here.

This pull request adds initial support for parties, which are mostly feature-complete, but several things are missing:
-Party members don't show up on the minimap yet, due to an unknown opcode that seems to be sent to the client around every 5 seconds when in a party, but this needs more research
-When anyone goes offline, they're removed from the party, or if the leader goes offline, the party is auto-disbanded, offline member support needs more testing, so I removed it for now and auto-kick/auto-disband instead
-Registering for content finder while in a party won't enlist the entire party and may potentially cause panics, I haven't tested it as leader yet
-Bonus stat stuff is not yet implemented
-Inviting a player to your party doesn't show a log message for unknown reasons

As for what it does support:
-Kicking, which will auto-disband when the party size is < 2
-Disbanding
-Leaving, which will auto-disband when the party size is < 2
-Joining
-Invites, both accepting and rejecting, including an inaccurate behaviour "shield" that prevents players from inviting others already in a different party (the client itself is supposed to handle this (?), but I was unable to make it work for now)
-Party chat

Other than that it's fairly well tested but it's possible I overlooked things here and there.