### PR TITLE
Don't panic if kawari-navimesh isn't found or can't run for some reason

### DIFF
--- a/src/world/server/mod.rs
+++ b/src/world/server/mod.rs
@@ -296,8 +296,7 @@ fn server_logic_tick(data: &mut WorldServer, network: &mut NetworkState) {
                     }
                     Err(err) => {
                         tracing::error!(
-                            "Unable to run kawari-navimesh due to the following error: {}",
-                            err
+                            "Unable to run kawari-navimesh due to the following error: {err}"
                         );
                         instance.generate_navmesh = NavmeshGenerationStep::None;
                     }


### PR DESCRIPTION
There's not much of a reason to crash the entire server if we can't run kawari-navimesh, especially when navmesh stuff is still very much experimental and not required for functionality currently.