### PR TITLE
Document a couple more jump states for UpdatePositionHandler

### DIFF
--- a/core/src/common/game.rs
+++ b/core/src/common/game.rs
@@ -175,6 +175,10 @@ pub enum JumpState {
     /// The player is descending back to the ground, or isn't jumping at all.
     #[default]
     NoneOrFalling = 0,
+    /// The player begins a gimmick path. Observed during S9 teleportation pads.
+    GimmickPathMoveBegin = 1,
+    /// THe player finishes a gimmick path. Observed during S9 teleportation pads.
+    GimmickPathMoveFinish = 2,
     /// The player is ascending to the apex of the jump.
     Ascending = 16,
 }


### PR DESCRIPTION
-These were observed during 7.4x S9 teleport pad usage. Unsure if they're new or if I just missed them previously.

This should reduce some "unknown" spam after landing at the gimmick's destination, and also fix the display of UPH items in PacketAnalyzer.