### PR TITLE
Fix Config opcode

### DIFF
--- a/resources/data/opcodes.yml
+++ b/resources/data/opcodes.yml
@@ -530,7 +530,7 @@ ClientZoneIpcType:
     size: 40
   - name: Config
     comment: Unknown purpose.
-    opcode: 176
+    opcode: 119
     size: 8
   - name: EventUnkRequest
     comment: Unknown purpose.


### PR DESCRIPTION
As reported on the dev chat, toggling visibility flags on weapons/hat/etc. wasn't functioning, due to an incorrect opcode.