### PR TITLE
Add clang to requirements

### DIFF
--- a/docs/src/setup/source.md
+++ b/docs/src/setup/source.md
@@ -10,6 +10,7 @@ This guide covers how to set up a local development environment.
 * Git
 * Rust toolchain
 * C/C++ development tools such as CMake (for the few C/C++ libraries we use)
+* Clang
 
 Clone the Kawari repository:
 


### PR DESCRIPTION
I needed [`clang`](https://archlinux.org/packages/extra/x86_64/clang/) to run `cargo run`, see build log below:

```
  running: cd "/data/Projects/Kawari/target/debug/build/recastnavigation-sys-761dcc30fc0db99e/out/build" && CMAKE_PREFIX_PATH="" LC_ALL="C" "cmake" "~/.cargo/git/checkouts/recastnavigation-rs-sys-11cc44d8858fb010/7bfacd6/recastnavigation" "-B" "/data/Projects/Kawari/target/debug/build/recastnavigation-sys-761dcc30fc0db99e/out/build" "-DRECASTNAVIGATION_DEMO=OFF" "-DRECASTNAVIGATION_EXAMPLES=OFF" "-DRECASTNAVIGATION_TESTS=OFF" "-DCMAKE_INSTALL_PREFIX=/data/Projects/Kawari/target/debug/build/recastnavigation-sys-761dcc30fc0db99e/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 -w" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 -w" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 -w" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Debug"
  running: cd "/data/Projects/Kawari/target/debug/build/recastnavigation-sys-761dcc30fc0db99e/out/build" && LC_ALL="C" MAKEFLAGS="-j --jobserver-fds=8,9 --jobserver-auth=8,9" "cmake" "--build" "/data/Projects/Kawari/target/debug/build/recastnavigation-sys-761dcc30fc0db99e/out/build" "--target" "install" "--config" "Debug"

  thread 'main' (522788) panicked at ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.72.1/lib.rs:616:27:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```