### PR TITLE
Add basic support for persistent target signs

### DIFF
--- a/servers/world/src/common.rs
+++ b/servers/world/src/common.rs
@@ -295,7 +295,7 @@ pub enum ToServer {
     /// The client is removing another player from the party.
     PartyMemberKick(u64, u64, u64, String, u64, String),
     /// The client changed areas.
-    PartyMemberChangedAreas(u64, u64, u64, String),
+    PartyMemberChangedAreas(u64, u64, u64, ObjectId, String),
     /// The client left their party.
     PartyMemberLeft(u64, u64, u64, ObjectId, String),
     /// The client disbands their party.

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -835,6 +835,7 @@ async fn process_packet(
                                             connection.player_data.character.service_account_id
                                                 as u64,
                                             connection.player_data.character.content_id as u64,
+                                            connection.player_data.character.actor_id,
                                             connection.player_data.character.name.clone(),
                                         ))
                                         .await;

--- a/servers/world/src/server/mod.rs
+++ b/servers/world/src/server/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         effect::{handle_effect_messages, remove_effect, send_effects_list},
         instance::{Instance, NavmeshGenerationStep, QueuedTaskData},
         network::{DestinationNetwork, NetworkState},
-        social::{get_party_id_from_actor_id, handle_social_messages},
+        social::{NUM_TARGET_SIGNS, get_party_id_from_actor_id, handle_social_messages},
         zone::{MapGimmick, change_zone_warp_to_entrance, handle_zone_messages},
     },
 };
@@ -1423,6 +1423,21 @@ pub async fn server_main_loop(
                             );
 
                             network.send_to_party_or_self(from_actor_id, msg);
+
+                            // If we're in a party, keep track of the actor that was just marked.
+                            if let Some(party_id) =
+                                get_party_id_from_actor_id(&network, from_actor_id)
+                            {
+                                let party = network.parties.get_mut(&party_id).unwrap();
+                                let sign_id = *sign_id as usize;
+                                if sign_id < NUM_TARGET_SIGNS {
+                                    party.target_signs[sign_id] = *target_actor;
+                                } else {
+                                    tracing::error!(
+                                        "Client tried to assign target sign id {sign_id}, but there are only {NUM_TARGET_SIGNS} currently known. Update the constant if necessary!"
+                                    );
+                                }
+                            }
                         }
                         _ => tracing::warn!("Server doesn't know what to do with {:#?}", trigger),
                     }

--- a/servers/world/src/server/social.rs
+++ b/servers/world/src/server/social.rs
@@ -8,7 +8,7 @@ use crate::{
     server::{DestinationNetwork, WorldServer, actor::NetworkedActor, network::NetworkState},
 };
 use kawari::{
-    common::ObjectId,
+    common::{ObjectId, ObjectTypeId},
     ipc::zone::{
         OnlineStatus, OnlineStatusMask, PartyMemberEntry, PartyUpdateStatus, PlayerEntry,
         SocialListRequestType, SocialListUIFlags,
@@ -36,12 +36,16 @@ impl PartyMember {
     }
 }
 
+// The current amount of target signs available for the player's party to use.
+pub const NUM_TARGET_SIGNS: usize = 17;
+
 #[derive(Clone, Debug, Default)]
 pub struct Party {
     pub members: [PartyMember; PartyMemberEntry::NUM_ENTRIES],
     leader_id: ObjectId,
     pub chatchannel_id: u32, // There's no reason to store a full u64/ChatChannel here, as it's created properly in the chat connection!
     pub stratboard_realtime_host: Option<u64>, // Only one player can send a board or host real-time sharing at a time
+    pub target_signs: [ObjectTypeId; NUM_TARGET_SIGNS], // NOTE: We deviate from retail here, which seems to have per-instance lists of marked targets, and instead just have one per party for simplicity.
 }
 
 impl Party {
@@ -164,6 +168,29 @@ pub fn get_party_id_from_actor_id(network: &NetworkState, actor_id: ObjectId) ->
         }
     }
     None
+}
+
+/// Helper function to send the party's currently marked targets to a specific actor that changed areas or returned from being offline.
+fn send_party_target_signs(network: &mut NetworkState, party_id: u64, execute_actor_id: ObjectId) {
+    let target_signs = match network.parties.get(&party_id) {
+        Some(p) => p.target_signs,
+        None => {
+            tracing::error!(
+                "send_party_target_signs was called with an invalid party id {party_id}! What happened? We won't be sending the markers for this player."
+            );
+            return;
+        }
+    };
+
+    for (sign_id, target_to_mark) in target_signs.iter().enumerate() {
+        // Don't need to send info for signs that don't have a valid target.
+        if target_to_mark.object_id != ObjectId::default() {
+            // When informing a client about existing markers, the server sets the sender as the blank actor id instead of the original player that marked the target.
+            let msg =
+                FromServer::TargetSignToggled(sign_id as u32, ObjectId::default(), *target_to_mark);
+            network.send_to_by_actor_id(execute_actor_id, msg, DestinationNetwork::ZoneClients);
+        }
+    }
 }
 
 /// Process social list and party-related messages.
@@ -585,11 +612,12 @@ pub fn handle_social_messages(
             party_id,
             execute_account_id,
             execute_content_id,
+            execute_actor_id,
             execute_name,
         ) => {
             let mut network = network.lock();
             let data = data.lock();
-            let party = network.parties.get_mut(party_id).unwrap();
+            let party = network.parties.get(party_id).unwrap();
 
             let party_list = build_party_list(party, &data);
 
@@ -606,6 +634,9 @@ pub fn handle_social_messages(
 
             // Finally, tell everyone in the party about the update.
             network.send_to_party(*party_id, None, msg, DestinationNetwork::ZoneClients);
+
+            // Next, inform the player about the party's target markers/signs.
+            send_party_target_signs(&mut network, *party_id, *execute_actor_id);
 
             true
         }
@@ -959,6 +990,9 @@ pub fn handle_social_messages(
             );
 
             network.send_to_party(party_id, None, msg, DestinationNetwork::ZoneClients);
+
+            // Next, inform the player about the party's target markers/signs.
+            send_party_target_signs(&mut network, party_id, *execute_actor_id);
 
             true
         }


### PR DESCRIPTION
This PR adds basic support for keeping track of target markers for longer. Meaning that when a player changes zones or goes offline and comes back, they'll be informed of all marked targets. There is no logic, meaning it doesn't account for multiple zones, instead providing one 'global' list per party, so if someone in one zone marks a target, and another player in a different zone marks a different target with the same marker, the first target will be unmarked. This deviates from retail, which *does* keep track of all of that, and seems to have per-zone lists.

For our goals, I think this implementation is sufficient for the time being.

Persistent waymarkers will come in a future PR.