### PR TITLE
Implement `Mogpendium` packet

### DIFF
--- a/core/src/ipc/zone/server/mod.rs
+++ b/core/src/ipc/zone/server/mod.rs
@@ -155,6 +155,9 @@ pub use linkshell::*;
 mod spawn_treasure;
 pub use spawn_treasure::SpawnTreasure;
 
+mod mogpendium;
+pub use mogpendium::{Mogpendium, MogpendiumCompletionFlags};
+
 mod cross_realm_listing;
 pub use cross_realm_listing::{CrossRealmListing, CrossRealmListings};
 
@@ -1323,6 +1326,7 @@ pub enum ServerZoneIpcData {
         position: Position,
         unk3: [u8; 4],
     },
+    Mogpendium(Mogpendium),
 }
 
 #[cfg(test)]

--- a/core/src/ipc/zone/server/mogpendium.rs
+++ b/core/src/ipc/zone/server/mogpendium.rs
@@ -1,0 +1,82 @@
+use binrw::binrw;
+use bitflags::bitflags;
+
+// Represents the progress of the *current* mogpendium
+#[binrw]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Mogpendium {
+    unk1: u32,
+    /// Always 0x18, Possible discriminator
+    unk2: u32,
+    /// Always 0x20, Possible discriminator
+    unk3: u32,
+    /// Unique and stable per character, observed in range of 1810000000 - 3000000000
+    /// Seems to be somewhat related to the owning character `content_id`, which exposes which server the character was originally created on
+    /// Eg. characters created on any US datacenter have ranges of 3000000000, while characters created on any EU datacenter have ranges of 1810000000.
+    /// This remains visible even when the character was transferred between datacenter regions years ago.
+    /// My initial thought was that these 4 bytes represent each weekly objective,
+    /// but they show no identical weekly challenge between characters that have the same byte at the same offset.
+    id_or_seed: u32,
+    /// Completion flags for weekly objectives
+    weekly_objective_flags: MogpendiumCompletionFlags,
+    unk4: [u8; 16],
+    /// Completion flags for minimog challenges
+    minimog_challenge_flags: MogpendiumCompletionFlags,
+    /// TODO: The progress count for the ultimog challenge is somewhere in there, I just don't care about treasure dungeons :(
+    unk5: [u8; 36],
+    /// Holds the progress count for the first minimog objective of the *current* week
+    minimog_objective_1_progress: u32,
+    /// Holds the progress count for the second minimog objective of the *current* week
+    minimog_objective_2_progress: u32,
+    unk6: [u8; 60],
+}
+
+impl Default for Mogpendium {
+    fn default() -> Self {
+        Self {
+            unk1: Default::default(),
+            unk2: Default::default(),
+            unk3: Default::default(),
+            id_or_seed: Default::default(),
+            weekly_objective_flags: Default::default(),
+            unk4: Default::default(),
+            minimog_challenge_flags: Default::default(),
+            unk5: [0; 36],
+            minimog_objective_1_progress: Default::default(),
+            minimog_objective_2_progress: Default::default(),
+            unk6: [0; 60],
+        }
+    }
+}
+
+/// Represents the completion state for a complete set of Mogpendium challenges.
+/// If a bitfield is `0`, it is either expired (past week) or incomplete (current week).
+#[binrw]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct MogpendiumCompletionFlags(u32);
+
+bitflags! {
+    impl MogpendiumCompletionFlags: u32 {
+        const NONE = 0;
+        const W1_COMPLETE = 1 << 0;
+        const W1_CLAIMED  = 1 << 1;
+        const W2_COMPLETE = 1 << 2;
+        const W2_CLAIMED  = 1 << 3;
+        const W3_COMPLETE = 1 << 4;
+        const W3_CLAIMED  = 1 << 5;
+        const W4_COMPLETE = 1 << 6;
+        const W4_CLAIMED  = 1 << 7;
+    }
+}
+
+impl std::fmt::Debug for MogpendiumCompletionFlags {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        bitflags::parser::to_writer(self, f)
+    }
+}
+
+impl Default for MogpendiumCompletionFlags {
+    fn default() -> Self {
+        MogpendiumCompletionFlags::NONE
+    }
+}

--- a/core/src/ipc/zone/server/mogpendium.rs
+++ b/core/src/ipc/zone/server/mogpendium.rs
@@ -5,30 +5,30 @@ use bitflags::bitflags;
 #[binrw]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Mogpendium {
-    unk1: u32,
+    pub unk1: u32,
     /// Always 0x18, Possible discriminator
-    unk2: u32,
+    pub unk2: u32,
     /// Always 0x20, Possible discriminator
-    unk3: u32,
+    pub unk3: u32,
     /// Unique and stable per character, observed in range of 1810000000 - 3000000000
     /// Seems to be somewhat related to the owning character `content_id`, which exposes which server the character was originally created on
     /// Eg. characters created on any US datacenter have ranges of 3000000000, while characters created on any EU datacenter have ranges of 1810000000.
     /// This remains visible even when the character was transferred between datacenter regions years ago.
     /// My initial thought was that these 4 bytes represent each weekly objective,
     /// but they show no identical weekly challenge between characters that have the same byte at the same offset.
-    id_or_seed: u32,
+    pub id_or_seed: u32,
     /// Completion flags for weekly objectives
-    weekly_objective_flags: MogpendiumCompletionFlags,
-    unk4: [u8; 16],
+    pub weekly_objective_flags: MogpendiumCompletionFlags,
+    pub unk4: [u8; 16],
     /// Completion flags for minimog challenges
-    minimog_challenge_flags: MogpendiumCompletionFlags,
+    pub minimog_challenge_flags: MogpendiumCompletionFlags,
     /// TODO: The progress count for the ultimog challenge is somewhere in there, I just don't care about treasure dungeons :(
-    unk5: [u8; 36],
+    pub unk5: [u8; 36],
     /// Holds the progress count for the first minimog objective of the *current* week
-    minimog_objective_1_progress: u32,
+    pub minimog_objective_1_progress: u32,
     /// Holds the progress count for the second minimog objective of the *current* week
-    minimog_objective_2_progress: u32,
-    unk6: [u8; 60],
+    pub minimog_objective_2_progress: u32,
+    pub unk6: [u8; 60],
 }
 
 impl Default for Mogpendium {

--- a/resources/data/opcodes.yml
+++ b/resources/data/opcodes.yml
@@ -715,6 +715,10 @@ ServerZoneIpcType:
     comment: The server informs the client about a piece of furniture that was placed in the world.
     opcode: 429
     size: 32
+  - name: Mogpendium
+    comment: Contains character specific Mogpendium progress data.
+    opcode: 535
+    size: 144
 ClientZoneIpcType:
   - name: InitRequest
     comment: Sent by the client when they successfully initialize with the server, and they need several bits of information (e.g. what zone to load.)


### PR DESCRIPTION
I was hoping that this packet contained the character specific weekly challenges, but I can't really figure it out.

It's still missing the ultimog challenge progress field. 