### PR TITLE
WIP/PoC: Initial support for managing housing items

### DIFF
--- a/core/src/ipc/zone/client/client_trigger.rs
+++ b/core/src/ipc/zone/client/client_trigger.rs
@@ -6,6 +6,7 @@ use crate::common::{
     read_bool_from, write_bool_as,
 };
 use crate::ipc::zone::WaymarkPosition;
+use crate::ipc::zone::client::HouseId;
 
 #[binrw]
 #[derive(Debug, PartialEq, Clone, IntoStaticStr)]
@@ -299,15 +300,21 @@ pub enum ClientTriggerCommand {
         ward_index: u32,
     },
 
-    /// The client removes a piece of furniture from the world and puts it in their inventory.
+    /// The client removes a piece of furniture from the world and puts it in their inventory or the storeroom.
     // TODO: Research is still ongoing for this one
     #[brw(magic = 1113u32)]
     MoveHousingItemToInventory {
-        unk1: u32,
-        unk2: u32,
-        #[brw(pad_after = 2)]
+        /// The house's id.
+        house_id: HouseId,
+        /// The source container to move the item from.
         storage_id: ContainerType,
-        unk4: u32,
+        unk1: [u8; 2], // likely padding
+        /// The slot that contains the desired item.
+        slot: u16,
+        /// If the item should be moved to the storeroom or not.
+        #[br(map = read_bool_from::<u16>)]
+        #[bw(map = write_bool_as::<u16>)]
+        to_storeroom: bool, // TODO: This might actually just be a u8
     },
 
     /// The client requests the housing inventory be sent to them. This happens automatically after opening the Interior Furnishings menu.
@@ -321,19 +328,11 @@ pub enum ClientTriggerCommand {
 
     /// The client opens or closes the Interior Furnishings menu.
     #[brw(magic = 1123u32)]
-    OpenOrCloseFurnitureMenu {
+    FurnitureMenuToggled {
         /// If the menu was closed or not.
         #[br(map = read_bool_from::<u32>)]
         #[bw(map = write_bool_as::<u32>)]
         closed: bool,
-    },
-
-    /// The client sets the interior lighting level.
-    #[brw(magic = 1137u32)]
-    SetInteriorLightLevel {
-        /// See HousingInteriorDetails in housing_interior_furniture.rs for further details, but `level` is actually a level of *darkness*, not light, so this CT is a misnomer, but it's more intuitive to just call it a light level...
-        level: u32,
-        unk: u32, // Seems to be always 1
     },
 
     /// The client requests to warp to the housing interior's front door.
@@ -345,6 +344,26 @@ pub enum ClientTriggerCommand {
     RequestApartmentList {
         /// The desired starting index of apartments.
         starting_index: u32,
+    },
+
+    /// The client sets the interior lighting level.
+    #[brw(magic = 1137u32)]
+    SetInteriorLightLevel {
+        /// See HousingInteriorDetails in housing_interior_furniture.rs for further details, but `level` is actually a level of *darkness*, not light, so this CT is a misnomer, but it's more intuitive to just call it a light level...
+        level: u32,
+        unk: u32, // Seems to be always 1
+    },
+
+    /// The client places furniture from the storeroom.
+    #[brw(magic = 1150u32)]
+    PlaceFurnitureFromStoreroom {
+        /// The house's id.
+        house_id: HouseId,
+        /// The source container to retrieve the item from.
+        container_type: ContainerType,
+        /// The index into the container.
+        container_index: u16,
+        unk: u16, // Just in case, observed as zeroes but with all this stuff lately, you never know.
     },
 
     /// The client requests to repair and item at a mender.

--- a/resources/scripts/events/custom/003/HouFixMansionEntrance_00359.lua
+++ b/resources/scripts/events/custom/003/HouFixMansionEntrance_00359.lua
@@ -15,6 +15,7 @@ end
 function onReturn(scene, results, player)
     local ENTER_LOBBY <const> = 1 -- The player chose to enter the apartment building lobby.
     local CANCEL_MENU <const> = -1 -- This is here for documentation purposes, no need to actually use it.
+    local ENTER_MY_APARTMENT <const> = 2 -- The player chose to enter their own apartment.
 
     -- TODO: Is there a mapping anywhere in Excel sheets that tell us how these link up? Initial findings seem to indicate no.
     local WARD_LOBBIES <const> = {
@@ -35,6 +36,11 @@ function onReturn(scene, results, player)
         else -- If it's nil we're already in a ward lobby most likely, and the option to enter a lobby from within a lobby makes no sense
             player:send_message("This option shouldn't be here and is a bug in Kawari, please select a different option.")
         end
+    elseif results[1] == ENTER_MY_APARTMENT then
+        player:finish_event()
+        local destination_zone = 609 -- Lily Hills Apartment, for now
+        player:change_territory(destination_zone, { x = 0.0, y = 0.0, z = 0.0}, 180.0) -- TODO: Are there popranges for this anywhere?
+        return
     end
     player:finish_event()
 end

--- a/servers/world/src/inventory/mod.rs
+++ b/servers/world/src/inventory/mod.rs
@@ -34,6 +34,8 @@ pub use crystals::{CrystalKind, CrystalsStorage};
 
 use crate::{GameData, ItemInfoQuery};
 
+use physis::TerritoryIntendedUse;
+
 const MAX_NORMAL_STORAGE: usize = 35;
 const MAX_LARGE_STORAGE: usize = 50;
 
@@ -539,4 +541,235 @@ impl Inventory {
 
         *self.equipped.get_slot_mut(slot) = Item::default();
     }
+}
+
+/// Represents a single housing plot's collective inventory, both inside and out.
+// TODO: This will need to adjustments in 7.5x
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HousingInventory {
+    //pub plot_size: kawari::ipc::zone::PlotSize,
+    pub interior: Vec<GenericStorage<MAX_LARGE_STORAGE>>,
+    pub interior_storeroom: Vec<GenericStorage<MAX_LARGE_STORAGE>>,
+    // TODO: Unclear if we need to emulate this
+    pub interior_appearance: Vec<GenericStorage<MAX_LARGE_STORAGE>>,
+    pub exterior: Vec<GenericStorage<MAX_LARGE_STORAGE>>,
+    pub exterior_storeroom: Vec<GenericStorage<MAX_LARGE_STORAGE>>,
+    // TODO: Unclear if we need to emulate this
+    pub exterior_appearance: Vec<GenericStorage<MAX_LARGE_STORAGE>>,
+}
+
+impl HousingInventory {
+    pub const INT_STORAGE_APT_FC: usize = 2;
+    pub const INT_STORAGE_SMALL: usize = 3;
+    pub const INT_STORAGE_MEDIUM: usize = 4;
+    pub const INT_STORAGE_MANSION: usize = 8;
+}
+
+// By default, be an apartment/fc chamber.
+impl Default for HousingInventory {
+    fn default() -> Self {
+        Self {
+            // plot_size: kawari::ipc::zone::PlotSize::Small,
+            interior: vec![
+                GenericStorage::<MAX_LARGE_STORAGE>::new(
+                    ContainerType::HousingInteriorPlacedItems1,
+                ),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(
+                    ContainerType::HousingInteriorPlacedItems2,
+                ),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(
+                    ContainerType::HousingInteriorPlacedItems3,
+                ),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(
+                    ContainerType::HousingInteriorPlacedItems4,
+                ),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(
+                    ContainerType::HousingInteriorPlacedItems5,
+                ),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(
+                    ContainerType::HousingInteriorPlacedItems6,
+                ),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(
+                    ContainerType::HousingInteriorPlacedItems7,
+                ),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(
+                    ContainerType::HousingInteriorPlacedItems8,
+                ),
+            ],
+            interior_storeroom: vec![
+                GenericStorage::<MAX_LARGE_STORAGE>::new(ContainerType::HousingInteriorStoreroom1),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(ContainerType::HousingInteriorStoreroom2),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(ContainerType::HousingInteriorStoreroom3),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(ContainerType::HousingInteriorStoreroom4),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(ContainerType::HousingInteriorStoreroom5),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(ContainerType::HousingInteriorStoreroom6),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(ContainerType::HousingInteriorStoreroom7),
+                GenericStorage::<MAX_LARGE_STORAGE>::new(ContainerType::HousingInteriorStoreroom8),
+            ],
+            interior_appearance: vec![GenericStorage::<MAX_LARGE_STORAGE>::new(
+                ContainerType::HousingExteriorAppearance,
+            )],
+
+            exterior: vec![GenericStorage::<MAX_LARGE_STORAGE>::new(
+                ContainerType::HousingExteriorPlacedItems,
+            )],
+            exterior_storeroom: vec![GenericStorage::<MAX_LARGE_STORAGE>::new(
+                ContainerType::HousingExteriorPlacedItems,
+            )],
+            exterior_appearance: vec![GenericStorage::<MAX_LARGE_STORAGE>::new(
+                ContainerType::HousingExteriorAppearance,
+            )],
+        }
+    }
+}
+
+impl HousingInventory {
+    pub fn add_in_empty_slot(
+        &mut self,
+        item: Item,
+        desired_pages: DesiredHousingInventoryPages,
+    ) -> Option<ItemInfo> {
+        let desired_pages = match desired_pages {
+            DesiredHousingInventoryPages::Interior => &mut self.interior,
+            DesiredHousingInventoryPages::InteriorStoreroom => &mut self.interior_storeroom,
+            DesiredHousingInventoryPages::Exterior => {
+                if !self.exterior.is_empty() {
+                    &mut self.exterior
+                } else {
+                    return None;
+                }
+            }
+            DesiredHousingInventoryPages::ExteriorStoreroom => {
+                if !self.exterior_storeroom.is_empty() {
+                    &mut self.exterior_storeroom
+                } else {
+                    return None;
+                }
+            }
+            DesiredHousingInventoryPages::None => {
+                return None;
+            }
+        };
+
+        for page in desired_pages {
+            for (slot_index, slot) in page.slots.iter_mut().enumerate() {
+                if slot.quantity == 0 {
+                    slot.clone_from(&item);
+                    return Some(ItemInfo {
+                        slot: slot_index as u16,
+                        container: page.kind,
+                        ..(*slot).into()
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    pub fn get_desired_pages_from_intendeduse(
+        &self,
+        intended_use: TerritoryIntendedUse,
+        storeroom: bool,
+    ) -> DesiredHousingInventoryPages {
+        match intended_use {
+            TerritoryIntendedUse::HousingOutdoor => {
+                if storeroom {
+                    DesiredHousingInventoryPages::ExteriorStoreroom
+                } else {
+                    DesiredHousingInventoryPages::Exterior
+                }
+            }
+            TerritoryIntendedUse::HousingIndoor => {
+                if storeroom {
+                    DesiredHousingInventoryPages::InteriorStoreroom
+                } else {
+                    DesiredHousingInventoryPages::Interior
+                }
+            }
+            _ => DesiredHousingInventoryPages::None,
+        }
+    }
+
+    fn get_container_mut(&mut self, container_type: &ContainerType) -> &mut dyn Storage {
+        match container_type {
+            ContainerType::HousingInteriorPlacedItems1 => &mut self.interior[0],
+            ContainerType::HousingInteriorPlacedItems2 => &mut self.interior[1],
+            ContainerType::HousingInteriorPlacedItems3 => &mut self.interior[2],
+            ContainerType::HousingInteriorPlacedItems4 => &mut self.interior[3],
+            ContainerType::HousingInteriorPlacedItems5 => &mut self.interior[4],
+            ContainerType::HousingInteriorPlacedItems6 => &mut self.interior[5],
+            ContainerType::HousingInteriorPlacedItems7 => &mut self.interior[6],
+            ContainerType::HousingInteriorPlacedItems8 => &mut self.interior[7],
+
+            ContainerType::HousingInteriorStoreroom1 => &mut self.interior_storeroom[0],
+            ContainerType::HousingInteriorStoreroom2 => &mut self.interior_storeroom[1],
+            ContainerType::HousingInteriorStoreroom3 => &mut self.interior_storeroom[2],
+            ContainerType::HousingInteriorStoreroom4 => &mut self.interior_storeroom[3],
+            ContainerType::HousingInteriorStoreroom5 => &mut self.interior_storeroom[4],
+            ContainerType::HousingInteriorStoreroom6 => &mut self.interior_storeroom[5],
+            ContainerType::HousingInteriorStoreroom7 => &mut self.interior_storeroom[6],
+            ContainerType::HousingInteriorStoreroom8 => &mut self.interior_storeroom[7],
+
+            ContainerType::HousingInteriorAppearance => &mut self.interior_appearance[0],
+            ContainerType::HousingExteriorAppearance => &mut self.exterior_appearance[0],
+
+            ContainerType::HousingExteriorPlacedItems => &mut self.exterior[0],
+            ContainerType::HousingExteriorStoreroom => &mut self.exterior_storeroom[0],
+            _ => unimplemented!(),
+        }
+    }
+
+    pub fn get_container(&self, container_type: ContainerType) -> &dyn Storage {
+        match container_type {
+            ContainerType::HousingInteriorPlacedItems1 => &self.interior[0],
+            ContainerType::HousingInteriorPlacedItems2 => &self.interior[1],
+            ContainerType::HousingInteriorPlacedItems3 => &self.interior[2],
+            ContainerType::HousingInteriorPlacedItems4 => &self.interior[3],
+            ContainerType::HousingInteriorPlacedItems5 => &self.interior[4],
+            ContainerType::HousingInteriorPlacedItems6 => &self.interior[5],
+            ContainerType::HousingInteriorPlacedItems7 => &self.interior[6],
+            ContainerType::HousingInteriorPlacedItems8 => &self.interior[7],
+
+            ContainerType::HousingInteriorStoreroom1 => &self.interior_storeroom[0],
+            ContainerType::HousingInteriorStoreroom2 => &self.interior_storeroom[1],
+            ContainerType::HousingInteriorStoreroom3 => &self.interior_storeroom[2],
+            ContainerType::HousingInteriorStoreroom4 => &self.interior_storeroom[3],
+            ContainerType::HousingInteriorStoreroom5 => &self.interior_storeroom[4],
+            ContainerType::HousingInteriorStoreroom6 => &self.interior_storeroom[5],
+            ContainerType::HousingInteriorStoreroom7 => &self.interior_storeroom[6],
+            ContainerType::HousingInteriorStoreroom8 => &self.interior_storeroom[7],
+
+            ContainerType::HousingInteriorAppearance => &self.interior_appearance[0],
+            ContainerType::HousingExteriorAppearance => &self.exterior_appearance[0],
+
+            ContainerType::HousingExteriorPlacedItems => &self.exterior[0],
+            ContainerType::HousingExteriorStoreroom => &self.exterior_storeroom[0],
+            _ => unimplemented!(),
+        }
+    }
+
+    /// Helper functions to reduce boilerplate
+    pub fn get_item_mut(&mut self, storage_id: ContainerType, storage_index: u16) -> &mut Item {
+        let container = self.get_container_mut(&storage_id);
+        container.get_slot_mut(storage_index)
+    }
+
+    pub fn get_item(&self, storage_id: ContainerType, storage_index: u16) -> Item {
+        if storage_id == ContainerType::Invalid {
+            return Item::default();
+        }
+
+        let container = self.get_container(storage_id);
+        *container.get_slot(storage_index)
+    }
+}
+
+/// Used to decide which set of housing inventory pages to send.
+#[derive(Debug, Copy, Clone)]
+pub enum DesiredHousingInventoryPages {
+    None,
+    Exterior,
+    ExteriorStoreroom,
+    Interior,
+    InteriorStoreroom,
 }

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -16,7 +16,7 @@ use kawari::ipc::chat::ClientChatIpcData;
 
 use kawari::ipc::zone::{
     ActorControlCategory, CWLSLeaveReason, Conditions, ContentFinderUserAction, CrossRealmListing,
-    CrossRealmListings, EventType, LinkshellInviteResponse, MapEffects, MarketBoardItem,
+    CrossRealmListings, EventType, ItemInfo, LinkshellInviteResponse, MapEffects, MarketBoardItem,
     OnlineStatus, OnlineStatusMask, PlayerSetup, SceneFlags, SearchInfo, SocialListRequestType,
     TrustContent, TrustInformation, WarpType,
 };
@@ -50,6 +50,7 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 use kawari::common::INVENTORY_ACTION_ACK_GENERAL;
+use physis::TerritoryIntendedUse;
 
 fn spawn_main_loop(
     game_data: Arc<Mutex<GameData>>,
@@ -1439,6 +1440,134 @@ async fn process_packet(
                                 }
                                 ClientTriggerCommand::RequestApartmentList { starting_index } => {
                                     connection.send_apartment_list(starting_index).await;
+                                }
+                                // TODO: This needs to be networked
+                                ClientTriggerCommand::SetInteriorLightLevel { level, unk } => {
+                                    connection
+                                        .actor_control_self(
+                                            ActorControlCategory::InteriorLightLevel {
+                                                unk1: 0,
+                                                level,
+                                                unk2: unk,
+                                            },
+                                        )
+                                        .await;
+                                }
+                                ClientTriggerCommand::FurnitureMenuToggled { closed } => {
+                                    if !closed {
+                                        connection.conditions.set_condition(
+                                            kawari::ipc::zone::Condition::UsingHousingFunctions,
+                                        );
+
+                                        connection
+                                            .actor_control_self(
+                                                ActorControlCategory::FurnitureMenu {},
+                                            )
+                                            .await;
+                                    } else {
+                                        connection.conditions.remove_condition(
+                                            kawari::ipc::zone::Condition::UsingHousingFunctions,
+                                        );
+                                    }
+                                    connection.send_conditions().await;
+                                }
+                                ClientTriggerCommand::RequestHousingInventory { storeroom } => {
+                                    let intended_use;
+                                    {
+                                        let mut gamedata = connection.gamedata.lock();
+                                        intended_use = gamedata
+                                            .get_intended_use(
+                                                connection.player_data.volatile.zone_id as u32,
+                                            )
+                                            .unwrap_or(TerritoryIntendedUse::Jail);
+                                    }
+
+                                    let desired_pages = connection
+                                        .player_data
+                                        .house_inventory
+                                        .get_desired_pages_from_intendeduse(
+                                            intended_use,
+                                            storeroom,
+                                        );
+
+                                    connection.send_housing_inventory(desired_pages).await;
+                                }
+                                ClientTriggerCommand::MoveHousingItemToInventory {
+                                    to_storeroom,
+                                    storage_id,
+                                    slot,
+                                    ..
+                                } => {
+                                    tracing::info!(
+                                        "Client is moving item to inventory! {:#?} {:#?} {:#?}",
+                                        to_storeroom,
+                                        storage_id,
+                                        slot
+                                    );
+
+                                    let intended_use;
+                                    {
+                                        let mut gamedata = connection.gamedata.lock();
+                                        intended_use = gamedata
+                                            .get_intended_use(
+                                                connection.player_data.volatile.zone_id as u32,
+                                            )
+                                            .unwrap_or(TerritoryIntendedUse::Jail);
+                                    }
+
+                                    let desired_pages = connection
+                                        .player_data
+                                        .house_inventory
+                                        .get_desired_pages_from_intendeduse(
+                                            intended_use,
+                                            to_storeroom,
+                                        );
+
+                                    let transfer_item = connection
+                                        .player_data
+                                        .house_inventory
+                                        .get_item(storage_id, slot);
+
+                                    if (!to_storeroom
+                                        && connection
+                                            .player_data
+                                            .inventory
+                                            .add_in_next_free_slot(transfer_item)
+                                            .is_none())
+                                        || (to_storeroom
+                                            && connection
+                                                .player_data
+                                                .house_inventory
+                                                .add_in_empty_slot(transfer_item, desired_pages)
+                                                .is_none())
+                                    {
+                                        continue;
+                                    }
+
+                                    // This is a bit ugly, but we have to do this after that `if` to avoid borrowing the house inventory twice...
+                                    let transfer_item = connection
+                                        .player_data
+                                        .house_inventory
+                                        .get_item_mut(storage_id, slot);
+                                    *transfer_item = Item::default();
+
+                                    // TODO: We should only send the affected container, not all of the pages, but for now it doesn't hurt anything
+                                    connection.send_inventory().await;
+
+                                    // Here we do want to send all of the housing inventory pages
+                                    connection.send_housing_inventory(desired_pages).await;
+
+                                    // TODO: This probably needs to be networked if the source furniture was placed in the world
+                                    connection
+                                        .actor_control_self(
+                                            ActorControlCategory::FurnitureRemovedToInventoryAck {
+                                                unk1: 0, // TODO: unk1 is actually filled with data, it might be an index of some sort
+                                                unk2: 0,
+                                                unk3: 0,
+                                                unk4: 0,
+                                            },
+                                        )
+                                        .await;
                                 }
                                 _ => {
                                     // inform the server of our trigger, it will handle sending it to other clients
@@ -2996,11 +3125,145 @@ async fn process_packet(
                                 }
                             }
                         }
-                        ClientZoneIpcData::PlaceFurniture { .. } => {
-                            tracing::warn!("Placing furniture is unimplemented");
+                        ClientZoneIpcData::PlaceFurniture {
+                            container,
+                            slot,
+                            position,
+                            ..
+                        } => {
+                            tracing::info!(
+                                "Client placed furniture! {:#?} {:#?} {:#?}",
+                                container,
+                                slot,
+                                position,
+                            );
+
+                            let intended_use;
+                            {
+                                let mut gamedata = connection.gamedata.lock();
+                                intended_use = gamedata
+                                    .get_intended_use(
+                                        connection.player_data.volatile.zone_id as u32,
+                                    )
+                                    .unwrap_or(TerritoryIntendedUse::Jail);
+                            }
+
+                            if intended_use != TerritoryIntendedUse::HousingIndoor
+                                && intended_use != TerritoryIntendedUse::HousingOutdoor
+                            {
+                                tracing::error!(
+                                    "The player attempted to place furniture while not within a housing zone! Rejecting request!"
+                                );
+                                continue;
+                            }
+
+                            let transfer_item = connection.player_data.inventory.pages
+                                [*container as usize]
+                                .get_slot(*slot);
+
+                            let catalog_id;
+                            {
+                                let mut gamedata = connection.gamedata.lock();
+                                let result =
+                                    gamedata.get_furniture_catalog_id(transfer_item.item_id);
+                                catalog_id = result.unwrap_or_default();
+                            }
+
+                            let desired_pages = connection
+                                .player_data
+                                .house_inventory
+                                .get_desired_pages_from_intendeduse(intended_use, false);
+
+                            let Some(result) = connection
+                                .player_data
+                                .house_inventory
+                                .add_in_empty_slot(*transfer_item, desired_pages)
+                            else {
+                                tracing::error!(
+                                    "Unable to add item to this housing inventory, it's full!"
+                                );
+                                continue;
+                            };
+
+                            // Next, remove the item from the player's main inventory.
+                            {
+                                let old_slot = connection.player_data.inventory.pages
+                                    [*container as usize]
+                                    .get_slot_mut(*slot);
+                                *old_slot = Item::default();
+
+                                let ipc = ServerZoneIpcSegment::new(
+                                    ServerZoneIpcData::UpdateInventorySlot(ItemInfo {
+                                        sequence: 0,
+                                        container: connection.player_data.inventory.pages
+                                            [*container as usize]
+                                            .kind,
+                                        slot: *slot,
+                                        ..(Item::default()).into()
+                                    }),
+                                );
+                                connection.send_ipc_self(ipc).await;
+                            }
+
+                            // Then send the refreshed housing inventory.
+                            connection.send_housing_inventory(desired_pages).await;
+
+                            // Finally, acknowledge the placement.
+                            // TODO: This needs to be networked so other players can see the results
+                            // TODO: We need to store the coordinates when things are persistent
+                            connection
+                                .send_ipc_self(ServerZoneIpcSegment::new(
+                                    ServerZoneIpcData::FurniturePlaced {
+                                        storage_id: result.container,
+                                        slot: result.slot,
+                                        catalog_id,
+                                        unk1: 1,
+                                        stain: 0,
+                                        unk2: 0,
+                                        unk3: 0,
+                                        unk4: 0,
+                                        position: *position,
+                                        unk5: [0; 4],
+                                    },
+                                ))
+                                .await;
+
+                            connection
+                                .actor_control_self(ActorControlCategory::FurniturePlacedAck {
+                                    unk1: 0,
+                                    unk2: 0,
+                                    unk3: 0,
+                                    unk4: 0,
+                                })
+                                .await;
                         }
-                        ClientZoneIpcData::TranslateFurniture { .. } => {
-                            tracing::warn!("Moving and rotating furniture is unimplemented");
+                        ClientZoneIpcData::TranslateFurniture {
+                            house_id,
+                            slot,
+                            position,
+                            rotation,
+                            unk2,
+                            unk3,
+                        } => {
+                            tracing::info!(
+                                "Client moved furniture! {:#?} {:#?}, {:#?}, {:#?} {:#?} {:#?}",
+                                house_id,
+                                slot,
+                                position,
+                                rotation,
+                                unk2,
+                                unk3
+                            );
+                            // TODO: We need to store the new coordinates and rotation when making everything persistent!
+                            // TODO: This process needs to be networked!
+                            // TODO: this storage_id is likely wrong!
+                            connection
+                                .actor_control_self(ActorControlCategory::FurnitureTranslatedAck {
+                                    storage_id: ContainerType::HousingInteriorPlacedItems1,
+                                    slot: *slot as u32,
+                                    unk1: 0,
+                                })
+                                .await;
                         }
                         ClientZoneIpcData::Unknown { unk } => {
                             tracing::warn!(

--- a/servers/world/src/zone_connection/item.rs
+++ b/servers/world/src/zone_connection/item.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     ItemInfoQuery, ToServer, ZoneConnection,
-    inventory::{EQUIP_RESTRICTED, Item, Storage},
+    inventory::{DesiredHousingInventoryPages, EQUIP_RESTRICTED, Item, Storage},
 };
 use kawari::{
     common::{ContainerType, ItemOperationKind, ObjectId},
@@ -223,6 +223,65 @@ impl ZoneConnection {
 
         self.send_stats().await;
         self.update_class_info().await;
+    }
+
+    pub async fn send_housing_inventory(&mut self, which: DesiredHousingInventoryPages) {
+        let cloned_inv = match which {
+            DesiredHousingInventoryPages::Interior => {
+                self.player_data.house_inventory.interior.clone()
+            }
+            DesiredHousingInventoryPages::InteriorStoreroom => {
+                self.player_data.house_inventory.interior_storeroom.clone()
+            }
+            DesiredHousingInventoryPages::Exterior => {
+                self.player_data.house_inventory.exterior.clone()
+            }
+            DesiredHousingInventoryPages::ExteriorStoreroom => {
+                self.player_data.house_inventory.exterior_storeroom.clone()
+            }
+            DesiredHousingInventoryPages::None => {
+                return;
+            }
+        };
+
+        // TODO: Since this is mostly copy-pasted, maybe create a common function that does the actual sending, shared with the regular inventory?
+        for (sequence, container) in cloned_inv.into_iter().enumerate() {
+            let mut num_items = 0;
+
+            // items
+            let mut send_slot = async |slot: u16, item: &Item| {
+                // skip telling the client what they don't have
+                if item.quantity == 0 || item.item_id == 0 {
+                    return;
+                }
+
+                let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::UpdateItem(ItemInfo {
+                    sequence: sequence as u32,
+                    container: container.kind,
+                    slot,
+                    ..(*item).into()
+                }));
+                self.send_ipc_self(ipc).await;
+
+                num_items += 1;
+            };
+
+            for i in 0..container.max_slots() {
+                send_slot(i as u16, container.get_slot(i as u16)).await;
+            }
+
+            // inform the client of container state
+            {
+                let ipc =
+                    ServerZoneIpcSegment::new(ServerZoneIpcData::ContainerInfo(ContainerInfo {
+                        container: container.kind,
+                        num_items,
+                        sequence: sequence as u32,
+                        ..Default::default()
+                    }));
+                self.send_ipc_self(ipc).await;
+            }
+        }
     }
 
     pub async fn send_inventory_ack(&mut self, sequence: u32, action_type: u16) {

--- a/servers/world/src/zone_connection/mod.rs
+++ b/servers/world/src/zone_connection/mod.rs
@@ -35,7 +35,7 @@ use kawari::{
 use super::{
     WorldDatabase,
     common::{ClientId, ServerHandle},
-    inventory::{BuyBackList, Inventory},
+    inventory::{BuyBackList, HousingInventory, Inventory},
 };
 
 mod actor;
@@ -107,6 +107,8 @@ pub struct PlayerData {
     pub saw_inn_wakeup: bool,
     pub friends: Friends,
     pub grand_company: GrandCompany,
+    // TODO: These inventories need to be made persistent and also vary per property, this is just for initial support
+    pub house_inventory: HousingInventory,
 }
 
 /// Various obsfucation-related bits like the seeds and keys for this connection.
@@ -406,6 +408,15 @@ impl ZoneConnection {
 
     // TODO: break this out into its own housing file eventually
     pub async fn send_apartment_list(&mut self, starting_index: u32) {
+        let mut apartments = vec![ApartmentListEntry::default(); ApartmentListEntry::COUNT];
+        apartments[0] = ApartmentListEntry {
+            resident_online_status_mask: self.get_online_status_mask(),
+            resident_zone_id: self.player_data.volatile.zone_id as u16,
+            resident_name: self.player_data.character.name.clone(),
+            apartment_description: "A test apartment provided to you by Kawari!".to_string(),
+            ..Default::default()
+        };
+
         let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::ApartmentList(ApartmentList {
             content_id: self.player_data.character.content_id as u64,
             flags: 128,
@@ -413,7 +424,7 @@ impl ZoneConnection {
             zone_id: self.player_data.volatile.zone_id as u16, // TODO: Apartment lists can be requested from apartments themselves, so this wouldn't make sense there!
             world_id: self.config.world_id,
             list_index: starting_index,
-            apartments: vec![ApartmentListEntry::default(); ApartmentListEntry::COUNT],
+            apartments,
         }));
         self.send_ipc_self(ipc).await;
     }

--- a/servers/world/src/zone_connection/social.rs
+++ b/servers/world/src/zone_connection/social.rs
@@ -346,7 +346,7 @@ impl ZoneConnection {
     }
 
     /// Determine the online status mask, with party/novice/mentor status.
-    fn get_online_status_mask(&self) -> OnlineStatusMask {
+    pub fn get_online_status_mask(&self) -> OnlineStatusMask {
         let mut database = self.database.lock();
         database.determine_online_status_mask(self.player_data.character.content_id)
     }

--- a/servers/world/src/zone_connection/zone.rs
+++ b/servers/world/src/zone_connection/zone.rs
@@ -6,7 +6,9 @@ use crate::{
     lua::{LuaContent, LuaZone},
 };
 use kawari::{
-    common::{HandlerId, HandlerType, HouseId, HouseUnit, HousingFlag, Position, timestamp_secs},
+    common::{
+        HandlerId, HandlerType, HouseId, HouseUnit, HousingFlag, LandData, Position, timestamp_secs,
+    },
     config::get_config,
     constants::OBFUSCATION_ENABLED_MODE,
     ipc::zone::{
@@ -129,7 +131,21 @@ impl ZoneConnection {
                 unk3: Default::default(),
                 unk4: Default::default(),
                 unk5: Default::default(),
-                apartment: Default::default(),
+                apartment: LandData {
+                    id: HouseId {
+                        unit: HouseUnit {
+                            apartment_division_plot_index: 0,
+                            apartment_flag: true,
+                        },
+                        unk1: 0,
+                        ward_index: 0,
+                        room_number: 1,
+                        territory_type_id: 340,
+                        world_id: config.world.world_id,
+                    },
+                    flags: 19,
+                    unk1: 0,
+                },
             });
             self.send_ipc_self(ipc).await;
         }
@@ -295,12 +311,12 @@ impl ZoneConnection {
                     id: HouseId {
                         unit: HouseUnit {
                             apartment_division_plot_index: 0,
-                            apartment_flag: false,
+                            apartment_flag: true,
                         },
                         unk1: 0,
-                        room_number: 0,
-                        ward_index: 1,
-                        territory_type_id: lua_zone.zone_id,
+                        room_number: 1,
+                        ward_index: 0,
+                        territory_type_id: 340,
                         world_id: config.world.world_id,
                     },
                     count: 1,


### PR DESCRIPTION
-This is still pretty rough around the edges. The UI doesn't refresh properly all the time, and removing multiple placed items in a row may not work.

-Also implements house light levels (non-persistent)
-Also makes it so you can enter from an apartment building into a Lily Hills apartment, not heavily tested yet
-Items spawn only for you for now