### PR TITLE
Fix incorrect display of furniture in the world

### DIFF
--- a/core/src/ipc/zone/server/mod.rs
+++ b/core/src/ipc/zone/server/mod.rs
@@ -1312,12 +1312,12 @@ pub enum ServerZoneIpcData {
         /// Fourth generic parameter.
         param4: u32,
     },
-    FurniturePlaced {
+    InteriorFurniturePlaced {
         /// Which storage the furniture was placed into.
         storage_id: ContainerType,
         /// Which slot the furniture was placed into.
         slot: u16,
-        /// Supposedly the furniture's ModelKey. You should be able determine this from the FurnitureCatalogItemList Excel sheet. The row to that sheet can be obtained from the AdditionalData column on the Item Excel sheet.
+        /// The low 12 bits of the row number on the HousingFurniture sheet for this furniture. The row to that sheet can be obtained from the AdditionalData column on the Item Excel sheet. When the client receives this value, it then ORs it with 0x30000 to recreate the row number.
         catalog_id: u16,
         unk1: u16, // Always 1?
         /// The furniture's dye/stain.

--- a/resources/data/opcodes.yml
+++ b/resources/data/opcodes.yml
@@ -711,8 +711,8 @@ ServerZoneIpcType:
     comment: Seen during Gold Saucer GATE announcements.
     opcode: 556
     size: 32
-  - name: FurniturePlaced
-    comment: The server informs the client about a piece of furniture that was placed in the world.
+  - name: InteriorFurniturePlaced
+    comment: The server informs the client about a piece of furniture that was placed in the current housing interior.
     opcode: 429
     size: 32
   - name: Mogpendium

--- a/servers/world/src/gamedata.rs
+++ b/servers/world/src/gamedata.rs
@@ -26,7 +26,6 @@ use icarus::GilShopItem::GilShopItemSheet;
 use icarus::GimmickRect::{GimmickRectRow, GimmickRectSheet};
 use icarus::HalloweenNpcSelect::HalloweenNpcSelectSheet;
 use icarus::HousingAethernet::HousingAethernetSheet;
-use icarus::HousingFurniture::HousingFurnitureSheet;
 use icarus::HousingLandSet::HousingLandSetSheet;
 use icarus::InstanceContent::InstanceContentSheet;
 use icarus::Item::ItemSheet;
@@ -1514,19 +1513,23 @@ impl GameData {
         })
     }
 
-    /// Returns a piece of furniture's model key/catalog id from its item id.
+    /// Returns a piece of furniture's catalog id from its item id. In this context, "catalog id" means the low 12 bits of the furniture's row number on the HousingFurniture/HousingYardObject sheet, which is what we send to the client when placing furniture.
     pub fn get_furniture_catalog_id(&mut self, item_id: u32) -> Option<u16> {
         // First, we need the item's AdditionalData column to point us to where we need to look on the HousingFurniture sheet.
         let row = self.item_sheet.row(item_id)?;
+        let item_ui_category = row.ItemUICategory();
+
+        // TODO: A better way to do this is checking if the link in AdditionalData leads to the HousingFurniture/HousingYardObject sheet or not.
+        // In order: Furnishing, Outdoor Furnishing, Table, Tabletop, Wall-mounted, Rug
+        let acceptable_ui_categories = [57, 76, 77, 78, 79, 80];
         let next_row = row.AdditionalData();
 
-        // Next, grab the row from the HousingFurniture sheet and return the ModelKey column's value. This value is the same as the catalog id.
-        let sheet = HousingFurnitureSheet::read_from(&mut self.resource, Language::None).ok()?;
-        let row = sheet.row(next_row)?;
+        // If the item is a piece of furniture, return the low 12 bits of the row number.
+        if acceptable_ui_categories.contains(&item_ui_category) && next_row != 0 {
+            return Some((next_row & 0x0FFF) as u16);
+        }
 
-        let model_key = row.ModelKey();
-
-        Some(model_key)
+        None
     }
 }
 

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -3211,9 +3211,10 @@ async fn process_packet(
                             // Finally, acknowledge the placement.
                             // TODO: This needs to be networked so other players can see the results
                             // TODO: We need to store the coordinates when things are persistent
+                            // TODO: Outdoor furniture uses a different response opcode, so we need to send the appropriate one!
                             connection
                                 .send_ipc_self(ServerZoneIpcSegment::new(
-                                    ServerZoneIpcData::FurniturePlaced {
+                                    ServerZoneIpcData::InteriorFurniturePlaced {
                                         storage_id: result.container,
                                         slot: result.slot,
                                         catalog_id,


### PR DESCRIPTION
-The ModelKey column wasn't what we were looking for.
-Rename FurniturePlaced to InteriorFurniturePlaced, as outdoor furniture has a separate server response opcode.

The correct value turned out to be the low 12 bits of the HousingFurniture/HousingYardObject row number. The client then ORs that with 0x30000 to arrive back at the correct row number. 

For outdoor furniture it ORs with 0x20000, but we don't yet implement the outdoor response opcode, so that wasn't important to document just yet.