### PR TITLE
Implement networked interior lighting, and continue work on furniture management

### DIFF
--- a/core/src/ipc/zone/server/actor_control.rs
+++ b/core/src/ipc/zone/server/actor_control.rs
@@ -764,6 +764,15 @@ pub enum ActorControlCategory {
         slot: u32,
     },
 
+    /// The server sets the interior lighting level for an observing client.
+    #[brw(magic = 1034u32)]
+    InteriorLightLevelForObserver {
+        /// The light level set by the resident.
+        level: u32,
+        /// Same unk from the resident's client trigger. It's always 1.
+        unk1: u32,
+    },
+
     /// The server sets the interior lighting level for the client.
     #[brw(magic = 1035u32)]
     InteriorLightLevel {

--- a/servers/world/src/common.rs
+++ b/servers/world/src/common.rs
@@ -11,8 +11,8 @@ use tokio::sync::mpsc::Sender;
 use crate::{StatusEffects, lua::LuaTask, server::Party, zone_connection::BaseParameters};
 use kawari::{
     common::{
-        CharacterMode, JumpState, LogMessageType, MoveAnimationState, MoveAnimationType, ObjectId,
-        ObjectTypeId, Position,
+        CharacterMode, ContainerType, JumpState, LogMessageType, MoveAnimationState,
+        MoveAnimationType, ObjectId, ObjectTypeId, Position,
     },
     ipc::{
         chat::{CWLinkshellMessage, ChatChannelType, PartyMessage, TellMessage},
@@ -223,6 +223,10 @@ pub enum FromServer {
     NewLetterArrived(),
     /// Plays a cutscene from the instance director.
     PlayDirectorCutscene(u32),
+    /// Inform the client that another player has placed a piece of furniture.
+    FurniturePlaced(ContainerType, u16, u16, u8, Position, bool),
+    /// Inform the client that another player has moved or rotated a piece of furniture.
+    FurnitureTranslated((bool, u8), u16, Position, f32, bool),
 }
 
 #[derive(Debug, Clone)]
@@ -450,6 +454,10 @@ pub enum ToServer {
     Call(ObjectId, String),
     /// Spawns an NPC defined by the layout or drop-in.
     SpawnLayoutNpc(ObjectId, u32),
+    /// The client places a piece of furniture.
+    PlaceFurniture(ObjectId, ContainerType, u16, u16, u8, Position, bool),
+    /// The client moves or rotates a piece of furniture.
+    TranslateFurniture(ObjectId, (bool, u8), u16, Position, f32, bool),
 }
 
 #[derive(Clone, Debug)]

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -16,9 +16,10 @@ use kawari::ipc::chat::ClientChatIpcData;
 
 use kawari::ipc::zone::{
     ActorControlCategory, CWLSLeaveReason, Conditions, ContentFinderUserAction, CrossRealmListing,
-    CrossRealmListings, EventType, ItemInfo, LinkshellInviteResponse, MapEffects, MarketBoardItem,
-    OnlineStatus, OnlineStatusMask, PlayerSetup, SceneFlags, SearchInfo, SocialListRequestType,
-    TrustContent, TrustInformation, WarpType,
+    CrossRealmListings, EventType, FurnitureTranslatedForObserver, ItemInfo,
+    LinkshellInviteResponse, MapEffects, MarketBoardItem, OnlineStatus, OnlineStatusMask,
+    PlayerSetup, SceneFlags, SearchInfo, SocialListRequestType, TrustContent, TrustInformation,
+    WarpType,
 };
 
 use kawari::ipc::zone::{
@@ -1475,6 +1476,15 @@ async fn process_packet(
                                             },
                                         )
                                         .await;
+
+                                    connection
+                                        .broadcast_actor_control(
+                                            ActorControlCategory::InteriorLightLevelForObserver {
+                                                level,
+                                                unk1: unk,
+                                            },
+                                        )
+                                        .await;
                                 }
                                 ClientTriggerCommand::FurnitureMenuToggled { closed } => {
                                     if !closed {
@@ -1582,9 +1592,9 @@ async fn process_packet(
 
                                     // TODO: This probably needs to be networked if the source furniture was placed in the world
                                     connection
-                                        .actor_control_self(
+                                        .broadcast_actor_control(
                                             ActorControlCategory::FurnitureRemovedToInventoryAck {
-                                                unk1: 0, // TODO: unk1 is actually filled with data, it might be an index of some sort
+                                                unk1: slot as u32,
                                                 unk2: 0,
                                                 unk3: 0,
                                                 unk4: 0,
@@ -3234,24 +3244,24 @@ async fn process_packet(
                             // Finally, acknowledge the placement.
                             // TODO: This needs to be networked so other players can see the results
                             // TODO: We need to store the coordinates when things are persistent
-                            // TODO: Outdoor furniture uses a different response opcode, so we need to send the appropriate one!
+                            let indoors = true; // TODO: Logic for outdoors
+                            // TODO: implement dyes...
+                            let stain = 0;
+
                             connection
-                                .send_ipc_self(ServerZoneIpcSegment::new(
-                                    ServerZoneIpcData::InteriorFurniturePlaced {
-                                        storage_id: result.container,
-                                        slot: result.slot,
-                                        catalog_id,
-                                        unk1: 1,
-                                        stain: 0,
-                                        unk2: 0,
-                                        unk3: 0,
-                                        unk4: 0,
-                                        position: *position,
-                                        unk5: [0; 4],
-                                    },
+                                .handle
+                                .send(ToServer::PlaceFurniture(
+                                    connection.player_data.character.actor_id,
+                                    result.container,
+                                    result.slot,
+                                    catalog_id,
+                                    stain,
+                                    *position,
+                                    indoors,
                                 ))
                                 .await;
 
+                            // This ack doesn't need to be networked
                             connection
                                 .actor_control_self(ActorControlCategory::FurniturePlacedAck {
                                     unk1: 0,
@@ -3279,11 +3289,27 @@ async fn process_packet(
                                 unk3
                             );
                             // TODO: We need to store the new coordinates and rotation when making everything persistent!
-                            // TODO: This process needs to be networked!
-                            // TODO: this storage_id is likely wrong!
+                            let indoors = true;
+                            connection
+                                .handle
+                                .send(ToServer::TranslateFurniture(
+                                    connection.player_data.character.actor_id,
+                                    // TODO: Maybe revise sending this tuple, we'll see
+                                    (
+                                        house_id.unit.apartment_flag,
+                                        house_id.unit.apartment_division_plot_index,
+                                    ),
+                                    *slot,
+                                    *position,
+                                    *rotation,
+                                    indoors,
+                                ))
+                                .await;
+
+                            // This ack doesn't need to be networked
                             connection
                                 .actor_control_self(ActorControlCategory::FurnitureTranslatedAck {
-                                    storage_id: ContainerType::HousingInteriorPlacedItems1,
+                                    storage_id: ContainerType::HousingInteriorPlacedItems1, // TODO: This storage_id is wrong!
                                     slot: *slot as u32,
                                     unk1: 0,
                                 })
@@ -3744,6 +3770,49 @@ async fn process_server_msg(
                         vec![cutscene_id, 1, 38, 1, 0],
                     );
                 }
+            }
+            FromServer::FurniturePlaced(
+                storage_id,
+                slot,
+                catalog_id,
+                stain,
+                position,
+                _indoors,
+            ) => {
+                // TODO: needs outdoor logic to send ExteriorFurniturePlaced instead when relevant
+                connection
+                    .send_ipc_self(ServerZoneIpcSegment::new(
+                        ServerZoneIpcData::InteriorFurniturePlaced {
+                            storage_id,
+                            slot,
+                            catalog_id,
+                            unk1: 1,
+                            stain: stain as u16,
+                            unk2: 0,
+                            unk3: 0,
+                            unk4: 0,
+                            position,
+                            unk5: [0; 4],
+                        },
+                    ))
+                    .await;
+            }
+            FromServer::FurnitureTranslated(_plot_info, slot, position, rotation, _indoors) => {
+                // TODO: needs outdoor logic for `plot_and_index`
+                connection
+                    .send_ipc_self(ServerZoneIpcSegment::new(
+                        ServerZoneIpcData::FurnitureTranslatedForObserver(
+                            FurnitureTranslatedForObserver {
+                                rotation,
+                                plot_and_index: slot,
+                                unk1: [0; 2],
+                                position,
+                                unk2: [0; 4],
+                                ..Default::default()
+                            },
+                        ),
+                    ))
+                    .await;
             }
             _ => {
                 tracing::error!(

--- a/servers/world/src/server/zone.rs
+++ b/servers/world/src/server/zone.rs
@@ -1389,6 +1389,69 @@ pub fn handle_zone_messages(
 
             true
         }
+        ToServer::PlaceFurniture(
+            from_actor_id,
+            container,
+            slot,
+            catalog_id,
+            stain,
+            position,
+            indoors,
+        ) => {
+            let mut network = network.lock();
+            let data = data.lock();
+
+            let Some(instance) = data.find_actor_instance(*from_actor_id) else {
+                return true;
+            };
+
+            let msg = FromServer::FurniturePlaced(
+                *container,
+                *slot,
+                *catalog_id,
+                *stain,
+                *position,
+                *indoors,
+            );
+
+            // We *do* want to include the sender here
+            network.send_in_range_inclusive_instance(
+                *from_actor_id,
+                instance,
+                msg,
+                DestinationNetwork::ZoneClients,
+            );
+
+            true
+        }
+        ToServer::TranslateFurniture(
+            from_actor_id,
+            plot_info,
+            slot,
+            position,
+            rotation,
+            indoors,
+        ) => {
+            let mut network = network.lock();
+            let data = data.lock();
+
+            let Some(instance) = data.find_actor_instance(*from_actor_id) else {
+                return true;
+            };
+
+            let msg =
+                FromServer::FurnitureTranslated(*plot_info, *slot, *position, *rotation, *indoors);
+
+            // We *don't* want to include the sender here
+            network.send_in_range_instance(
+                *from_actor_id,
+                instance,
+                msg,
+                DestinationNetwork::ZoneClients,
+            );
+
+            true
+        }
         _ => false,
     }
 }


### PR DESCRIPTION
-Interior lighting is now networked for everyone in the zone, but not for entering players yet
-Furniture management is now networked completely but existing furniture is not yet sent to players entering the zone
-Fixed furniture removal for the resident player