### PR TITLE
Implement spawning furniture from the storeroom and more

### DIFF
--- a/core/src/common/game.rs
+++ b/core/src/common/game.rs
@@ -675,8 +675,10 @@ pub enum LogMessageType {
     ItemSold = 0x698,
     ItemBoughtBack = 0x699,
     UnableToPerformPlayerOffline = 0x1617, // Unable to perform that action. That player is offline.
-    PlayerAlreadyInYourCWLS = 0x242e,      // Player is already a cross-world linkshell member.
+    PlayerAlreadyInYourCWLS = 0x242E,      // Player is already a cross-world linkshell member.
     UnableToAcceptAttachmentInventoryFull = 0x17B, // Unable to accept attachment. Inventory is full.
+    FurnitureMovedToStoreroom = 0xD9F,             // The <item name> was moved to your storeroom.
+    FurnitureMovedToInventory = 0xDA0,             // The <item name> was moved to your inventory.
 }
 
 /// Names for rows in the Excel sheet of the same name.

--- a/core/src/ipc/zone/client/mod.rs
+++ b/core/src/ipc/zone/client/mod.rs
@@ -42,8 +42,8 @@ pub use super::social_list::{
 use super::config::Config;
 use crate::common::{
     CHAR_NAME_MAX_LENGTH, ClientLanguage, HandlerId, HouseId, JumpState, MoveAnimationState,
-    MoveAnimationType, ObjectId, Position, read_sestring, read_string, write_sestring,
-    write_string,
+    MoveAnimationType, ObjectId, Position, read_bool_from, read_sestring, read_string,
+    write_bool_as, write_sestring, write_string,
 };
 use crate::opcodes::ClientZoneIpcType;
 use crate::packet::ServerIpcSegmentHeader;
@@ -612,9 +612,13 @@ pub enum ClientZoneIpcData {
         slot: u16,
         /// Where in the world the client has placed it.
         position: Position,
-        unk2: [u8; 4], // zeroes?
-        unk3: u32,     // Always 1?
-        unk4: [u8; 8], // zeroes?
+        /// The direction the furniture will be rotated towards when placed. This matters more for placing items from the storeroom, since in that case the furniture's front will face the player. The client sends 0.0 otherwise.
+        rotation: f32,
+        /// If true, this furniture will be spawned in the world, if false it should be placed into the storeroom. This seems to be false only when right-clicking furniture in the main inventory and selecting "Store". Otherwise, it seems to be always true.
+        #[br(map = read_bool_from::<u32>)]
+        #[bw(map = write_bool_as::<u32>)]
+        spawn_furniture: bool,
+        unk2: [u8; 8], // Zeroes?
     },
     TranslateFurniture {
         /// Which house this affects.

--- a/core/src/ipc/zone/server/mod.rs
+++ b/core/src/ipc/zone/server/mod.rs
@@ -1375,15 +1375,15 @@ pub enum ServerZoneIpcData {
         slot: u16,
         /// The low 12 bits of the row number on the HousingFurniture sheet for this furniture. The row to that sheet can be obtained from the AdditionalData column on the Item Excel sheet. When the client receives this value, it then ORs it with 0x30000 to recreate the row number.
         catalog_id: u16,
-        unk1: u16, // Always 1?
+        unk1: u16, // Always 1? Changing it seems to have no visible effect so far.
         /// The furniture's dye/stain.
-        stain: u16,
-        unk2: u16,
-        unk3: u16,
-        unk4: u16,
+        stain: u8,
+        unk2: [u8; 3],
+        /// The furniture's rotation. This is only used when placing furniture from the storeroom to ensure the furniture's front faces the player.
+        rotation: f32,
         /// The furniture's position.
         position: Position,
-        unk5: [u8; 4],
+        unk3: [u8; 4],
     },
     ExteriorFurniturePlaced {
         /// Likely the plot upon which this furniture was placed.
@@ -1397,11 +1397,11 @@ pub enum ServerZoneIpcData {
         /// The furniture's dye/stain.
         stain: u8,
         unk3: [u8; 3], // Likely just padding
-        /// The furniture's rotation. Strange, considering that the client cannot rotate an item until after it's placed...
+        /// The furniture's rotation. This is only used when placing furniture from the storeroom to ensure the furniture's front faces the player.
         rotation: f32,
         /// The furniture's position.
         position: Position,
-        unk5: u32, // Observed as zeroes
+        unk4: u32, // Observed as zeroes
     },
     Mogpendium(Mogpendium),
     PlayerName {

--- a/resources/data/opcodes.yml
+++ b/resources/data/opcodes.yml
@@ -1097,7 +1097,7 @@ ClientZoneIpcType:
     opcode: 296
     size: 32
   - name: PlaceFurniture
-    comment: The client places furniture on their property (indoors or outdoors).
+    comment: The client places furniture on their property (indoors or outdoors), or into the relevant storeroom (the furniture is not spawned in that case).
     opcode: 191
     size: 40
   - name: TranslateFurniture

--- a/servers/world/src/common.rs
+++ b/servers/world/src/common.rs
@@ -224,7 +224,7 @@ pub enum FromServer {
     /// Plays a cutscene from the instance director.
     PlayDirectorCutscene(u32),
     /// Inform the client that another player has placed a piece of furniture.
-    FurniturePlaced(ContainerType, u16, u16, u8, Position, bool),
+    FurniturePlaced(ContainerType, u16, u16, u8, Position, bool, f32),
     /// Inform the client that another player has moved or rotated a piece of furniture.
     FurnitureTranslated((bool, u8), u16, Position, f32, bool),
 }
@@ -455,7 +455,7 @@ pub enum ToServer {
     /// Spawns an NPC defined by the layout or drop-in.
     SpawnLayoutNpc(ObjectId, u32),
     /// The client places a piece of furniture.
-    PlaceFurniture(ObjectId, ContainerType, u16, u16, u8, Position, bool),
+    PlaceFurniture(ObjectId, ContainerType, u16, u16, u8, Position, bool, f32),
     /// The client moves or rotates a piece of furniture.
     TranslateFurniture(ObjectId, (bool, u8), u16, Position, f32, bool),
 }

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -5,7 +5,7 @@ use axum::Router;
 use axum::routing::get;
 use kawari::common::{
     ContainerType, DirectorEvent, DirectorTrigger, DutyOption, FestivalId, HandlerId, HandlerType,
-    ItemOperationKind, ObjectId, ObjectTypeId, ObjectTypeKind, PlayerStateFlags1,
+    ItemOperationKind, LogMessageType, ObjectId, ObjectTypeId, ObjectTypeKind, PlayerStateFlags1,
     PlayerStateFlags2, PlayerStateFlags3, Position, calculate_max_level,
 };
 use kawari::config::{FilesystemConfig, get_config};
@@ -1580,6 +1580,9 @@ async fn process_packet(
                                         continue;
                                     }
 
+                                    // Have to get this before deleting the item...
+                                    let item_id = transfer_item.item_id;
+
                                     // This is a bit ugly, but we have to do this after that `if` to avoid borrowing the house inventory twice...
                                     let transfer_item = connection
                                         .player_data
@@ -1595,6 +1598,18 @@ async fn process_packet(
                                     // Here we do want to send all of the housing inventory pages
                                     connection.send_housing_inventory(desired_pages).await;
 
+                                    // Inform the player via a log message where their item went.
+                                    connection
+                                        .actor_control_self(ActorControlCategory::LogMessage {
+                                            log_message: if to_storeroom {
+                                                LogMessageType::FurnitureMovedToStoreroom as u32
+                                            } else {
+                                                LogMessageType::FurnitureMovedToInventory as u32
+                                            },
+                                            id: item_id,
+                                        })
+                                        .await;
+
                                     // TODO: This probably needs to be networked only if the source furniture was placed in the world, and this is not a transfer from the storeroom to the player's inventory
                                     connection
                                         .broadcast_actor_control(
@@ -1605,6 +1620,48 @@ async fn process_packet(
                                                 unk4: 0,
                                             },
                                         )
+                                        .await;
+                                }
+                                ClientTriggerCommand::PlaceFurnitureFromStoreroom {
+                                    container_type,
+                                    container_index,
+                                    ..
+                                } => {
+                                    let catalog_id;
+                                    {
+                                        let mut gamedata = connection.gamedata.lock();
+                                        let Some(the_item) = connection
+                                            .player_data
+                                            .house_inventory
+                                            .get_item(container_type, container_index)
+                                        else {
+                                            continue;
+                                        };
+                                        let Some(the_id) =
+                                            gamedata.get_furniture_catalog_id(the_item.item_id)
+                                        else {
+                                            continue;
+                                        };
+
+                                        catalog_id = the_id;
+                                    }
+
+                                    // This acts as a preview, it doesn't actually spawn the furniture until the client sends a PlaceFurniture. Therefore, we don't network this.
+                                    // TODO: Outdoor logic
+                                    connection
+                                        .send_ipc_self(ServerZoneIpcSegment::new(
+                                            ServerZoneIpcData::InteriorFurniturePlaced {
+                                                storage_id: container_type,
+                                                slot: container_index,
+                                                catalog_id,
+                                                unk1: 1,
+                                                stain: 0,
+                                                unk2: [0; 3],
+                                                rotation: 0.0,
+                                                position: connection.player_data.volatile.position,
+                                                unk3: [0; 4],
+                                            },
+                                        ))
                                         .await;
                                 }
                                 _ => {
@@ -3163,7 +3220,7 @@ async fn process_packet(
                                 }
                                 _ => {
                                     tracing::info!(
-                                        "Client executed uninplemented world interaction {action} with params {param1} {param2} {param3} {param4}"
+                                        "Client executed unimplemented world interaction {action} with params {param1} {param2} {param3} {param4}"
                                     );
                                 }
                             }
@@ -3172,13 +3229,17 @@ async fn process_packet(
                             container,
                             slot,
                             position,
+                            rotation,
+                            spawn_furniture,
                             ..
                         } => {
                             tracing::info!(
-                                "Client placed furniture! {:#?} {:#?} {:#?}",
+                                "Client placed furniture! {:#?} {:#?} {:#?} {:#?} {:#?}",
                                 container,
                                 slot,
                                 position,
+                                rotation,
+                                spawn_furniture,
                             );
 
                             let intended_use;
@@ -3200,9 +3261,22 @@ async fn process_packet(
                                 continue;
                             }
 
-                            let transfer_item = connection.player_data.inventory.pages
-                                [*container as usize]
-                                .get_slot(*slot);
+                            let transfer_item = if let Some(the_item) =
+                                connection.player_data.inventory.get_item(*container, *slot)
+                            {
+                                the_item
+                            } else if let Some(the_item) = connection
+                                .player_data
+                                .house_inventory
+                                .get_item(*container, *slot)
+                            {
+                                the_item
+                            } else {
+                                tracing::error!(
+                                    "The client attempted to use an invalid container to place a furniture item! Rejecting request!"
+                                );
+                                continue;
+                            };
 
                             let catalog_id;
                             {
@@ -3215,12 +3289,12 @@ async fn process_packet(
                             let desired_pages = connection
                                 .player_data
                                 .house_inventory
-                                .get_desired_pages_from_intendeduse(intended_use, false);
+                                .get_desired_pages_from_intendeduse(intended_use, !spawn_furniture);
 
                             let Some(result) = connection
                                 .player_data
                                 .house_inventory
-                                .add_in_empty_slot(*transfer_item, desired_pages)
+                                .add_in_empty_slot(transfer_item, desired_pages)
                             else {
                                 tracing::error!(
                                     "Unable to add item to this housing inventory, it's full!"
@@ -3228,19 +3302,30 @@ async fn process_packet(
                                 continue;
                             };
 
-                            // Next, remove the item from the player's main inventory.
+                            // Next, remove the item from the player's main inventory or the storeroom.
                             {
-                                let old_slot = connection.player_data.inventory.pages
-                                    [*container as usize]
-                                    .get_slot_mut(*slot);
+                                let old_slot = if let Some(the_item) = connection
+                                    .player_data
+                                    .inventory
+                                    .get_item_mut(*container, *slot)
+                                {
+                                    the_item
+                                } else if let Some(the_item) = connection
+                                    .player_data
+                                    .house_inventory
+                                    .get_item_mut(*container, *slot)
+                                {
+                                    the_item
+                                } else {
+                                    continue; // This shouldn't even be reachable or possible but it's not overly desirable to crash intentionally, so we'll just skip over it.
+                                };
+
                                 *old_slot = Item::default();
 
                                 let ipc = ServerZoneIpcSegment::new(
                                     ServerZoneIpcData::UpdateInventorySlot(ItemInfo {
                                         sequence: 0,
-                                        container: connection.player_data.inventory.pages
-                                            [*container as usize]
-                                            .kind,
+                                        container: *container,
                                         slot: *slot,
                                         ..(Item::default()).into()
                                     }),
@@ -3251,8 +3336,12 @@ async fn process_packet(
                             // Then send the refreshed housing inventory.
                             connection.send_housing_inventory(desired_pages).await;
 
+                            // If the client opted to move furniture to the storeroom, there's nothing further to do here.
+                            if !spawn_furniture {
+                                continue;
+                            }
+
                             // Finally, acknowledge the placement.
-                            // TODO: This needs to be networked so other players can see the results
                             // TODO: We need to store the coordinates when things are persistent
                             let indoors = true; // TODO: Logic for outdoors
                             // TODO: implement dyes...
@@ -3268,6 +3357,7 @@ async fn process_packet(
                                     stain,
                                     *position,
                                     indoors,
+                                    *rotation,
                                 ))
                                 .await;
 
@@ -3788,6 +3878,7 @@ async fn process_server_msg(
                 stain,
                 position,
                 _indoors,
+                rotation,
             ) => {
                 // TODO: needs outdoor logic to send ExteriorFurniturePlaced instead when relevant
                 connection
@@ -3797,12 +3888,11 @@ async fn process_server_msg(
                             slot,
                             catalog_id,
                             unk1: 1,
-                            stain: stain as u16,
-                            unk2: 0,
-                            unk3: 0,
-                            unk4: 0,
+                            stain,
+                            unk2: [0; 3],
+                            rotation,
                             position,
-                            unk5: [0; 4],
+                            unk3: [0; 4],
                         },
                     ))
                     .await;

--- a/servers/world/src/server/zone.rs
+++ b/servers/world/src/server/zone.rs
@@ -1397,6 +1397,7 @@ pub fn handle_zone_messages(
             stain,
             position,
             indoors,
+            rotation,
         ) => {
             let mut network = network.lock();
             let data = data.lock();
@@ -1412,6 +1413,7 @@ pub fn handle_zone_messages(
                 *stain,
                 *position,
                 *indoors,
+                *rotation,
             );
 
             // We *do* want to include the sender here


### PR DESCRIPTION
-Polish things up a little more by sending log messages when moving items to the storeroom or to the main inventory
-Furniture can now be spawned from the storeroom
-Furniture can now be stored directly into the storeroom from the main inventory