### PR TITLE
Various equipment fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,7 +1268,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "physis"
 version = "0.6.0"
-source = "git+https://github.com/redstrate/physis#10f9c12c987c6f00f3494bd5698a47c0f3f9ebf6"
+source = "git+https://github.com/redstrate/physis#9085ad348c1bcde87f73efb4f3f7727e457f15c4"
 dependencies = [
  "binrw",
  "bitflags",
@@ -1596,9 +1596,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",
@@ -1784,7 +1784,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -1885,9 +1885,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -2033,9 +2033,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "xml"

--- a/servers/world/src/chat_handler.rs
+++ b/servers/world/src/chat_handler.rs
@@ -15,6 +15,7 @@ use kawari::{
         ServerZoneIpcSegment,
     },
 };
+use physis::equipment::EquipSlot;
 
 use super::ZoneConnection;
 
@@ -65,23 +66,63 @@ impl ChatHandler {
             }
             "!equip" => {
                 if let Some((_, name)) = chat_message.split_once(' ') {
+                    let item_info;
                     {
                         let mut gamedata = connection.gamedata.lock();
-
-                        if let Some(item_info) =
-                            gamedata.get_item_info(ItemInfoQuery::ByName(name.to_string()))
-                        {
-                            let slot = connection
-                                .player_data
-                                .inventory
-                                .equipped
-                                .get_slot_mut(item_info.equip_category as u16);
-                            *slot = Item::new(&item_info, 1);
-                        }
+                        item_info = gamedata.get_item_info(ItemInfoQuery::ByName(name.to_string()));
                     }
+                    if let Some(item_info) = item_info {
+                        // Reject belts that may have forgotten to be changed to 0 and items that aren't equipment.
+                        let belts_and_misc = [0, 6, 24]; // Invalid, belts, invalid respectively
+                        if belts_and_misc.contains(&item_info.equip_category) {
+                            connection.send_notice(&format!("[equip] The found item, {:#?}, isn't equipment! If the wrong item was found, try being more specific with its name, or consider using //gm item instead if you can't get the desired item from this command.", item_info.name).to_string()).await;
+                            return true;
+                        }
 
-                    connection.send_inventory().await;
-                    connection.inform_equip().await;
+                        // EquipSlotCategory rows belong to these slot types. There's currently no physis mechanism for this, so we'll hardcode it here for the time being.
+                        let main_hand = [1, 13, 14];
+                        let legs = [7, 18];
+                        let body = [4, 15, 16, 19, 20, 21, 22, 23];
+                        let soul_crystal = 17;
+
+                        // First, assume nothing special is going on. For most equipment you can just use the category minus one to get the correct slot.
+                        let mut slot = if let Some(the_slot) =
+                            EquipSlot::from_repr((item_info.equip_category - 1) as u16)
+                        {
+                            the_slot
+                        } else {
+                            EquipSlot::Waist // This should should never slip through since stuff like Herklaedi (category 16) or the Star Pilot Suit (category 23) will be caught below
+                        };
+
+                        // Convert more complicated EquipSlotCategory rows into proper slots.
+                        if main_hand.contains(&item_info.equip_category) {
+                            slot = EquipSlot::MainHand;
+                        } else if legs.contains(&item_info.equip_category) {
+                            slot = EquipSlot::Legs;
+                        } else if body.contains(&item_info.equip_category) {
+                            slot = EquipSlot::Body;
+                        } else if item_info.equip_category == soul_crystal {
+                            slot = EquipSlot::SoulCrystal;
+                        }
+
+                        assert!(slot != EquipSlot::Waist);
+
+                        let slot = connection
+                            .player_data
+                            .inventory
+                            .equipped
+                            .get_slot_mut(slot as u16);
+                        *slot = Item::new(&item_info, 1);
+
+                        connection.send_inventory().await;
+                        connection.inform_equip().await;
+                    } else {
+                        connection.send_notice(&format!("[equip] No items named {name:#?} were found! If you know its item id instead, consider using //gm item.").to_string()).await;
+                    }
+                } else {
+                    connection
+                        .send_notice("[equip] Usage: !equip <item name>")
+                        .await;
                 }
 
                 true


### PR DESCRIPTION
-Fixed the !equip debug command so it won't crash from being given bad EquipSlotCategories
-!equip will now use the ESCs properly to put soul crystals, multi-slot body and leg pieces, etc. where they belong. They won't remove the items they're supposed to though, since this command is intentionally breaking the rules.
-!equip will now send more helpful error messages when something goes wrong
-!equip will now reject bogus items (categories 0 & 24 on the ESC sheet) as well as reject belts (category 6) that may have been missed, if any still exist at this point

-Update physis and dependencies: the former will fix a bug where wrists and earrings were erroneously swapped/mixed up.