### PR TITLE
Refactor cwls invite logic

### DIFF
--- a/core/src/common/game.rs
+++ b/core/src/common/game.rs
@@ -675,11 +675,15 @@ pub enum LogMessageType {
     Default = 0,
     PlayerAlreadyFriend = 0x138, // That player is already a friend or has been sent a request. TODO: unclear if this one is sent by the server or the client keeps track of that itself
     PlayerAlreadyInAnotherParty = 0x146, // That player is already in another party.
+    UnableToAcceptLSInvite = 0x1DD, // Unable to accept linkshell invite.
     ItemBought = 0x697,
     ItemSold = 0x698,
     ItemBoughtBack = 0x699,
     UnableToPerformPlayerOffline = 0x1617, // Unable to perform that action. That player is offline.
-    PlayerAlreadyInYourCWLS = 0x242E,      // Player is already a cross-world linkshell member.
+    CWLSIsFull = 0x242B, // Unable to add new members. Cross-world linkshell roster is full.
+    UnableToInviteToCWLS = 0x242D, // Unable to invite to cross-world linkshell.
+    PlayerAlreadyInYourCWLS = 0x242E, // Player is already a cross-world linkshell member.
+    PlayerInTooManyCWLSes = 0x242F, // The person you have invited cannot join any more cross-world linkshells.
     UnableToAcceptAttachmentInventoryFull = 0x17B, // Unable to accept attachment. Inventory is full.
     FurnitureMovedToStoreroom = 0xD9F,             // The <item name> was moved to your storeroom.
     FurnitureMovedToInventory = 0xDA0,             // The <item name> was moved to your inventory.

--- a/core/src/ipc/zone/server/linkshell.rs
+++ b/core/src/ipc/zone/server/linkshell.rs
@@ -4,6 +4,9 @@ use strum_macros::FromRepr;
 use crate::common::{read_bool_from, write_bool_as};
 use crate::ipc::zone::server::{CHAR_NAME_MAX_LENGTH, ChatChannel, read_string, write_string};
 
+pub const CWLS_MAX_MEMBERS: usize = 64;
+pub const LWLS_MAX_MEMBERS: usize = 128;
+
 /// Represents one entry in the Linkshells opcode.
 #[binrw]
 #[derive(Clone, Debug, Default)]

--- a/servers/world/src/database/linkshell.rs
+++ b/servers/world/src/database/linkshell.rs
@@ -8,8 +8,9 @@ use kawari::{
     config::get_config,
     ipc::chat::{ChatChannel, ChatChannelType},
     ipc::zone::{
-        CWLSCommon, CWLSCommonIdentifiers, CWLSMemberListEntry, CWLSNameAvailability,
-        CWLSPermissionRank, CrossworldLinkshellEx, OnlineStatusMask,
+        CWLS_MAX_MEMBERS, CWLSCommon, CWLSCommonIdentifiers, CWLSMemberListEntry,
+        CWLSNameAvailability, CWLSPermissionRank, CrossworldLinkshellEx, LWLS_MAX_MEMBERS,
+        OnlineStatusMask,
     },
 };
 
@@ -245,6 +246,41 @@ impl WorldDatabase {
         Some(members)
     }
 
+    pub fn is_linkshell_crossworld(&mut self, for_linkshell_id: u64) -> Option<bool> {
+        use schema::linkshells::dsl::*;
+
+        if let Ok(crossworld) = linkshells
+            .select(is_crossworld)
+            .filter(id.eq(for_linkshell_id as i64))
+            .first::<bool>(&mut self.connection)
+        {
+            return Some(crossworld);
+        }
+
+        None
+    }
+
+    pub fn is_linkshell_full(&mut self, for_linkshell_id: u64) -> Option<bool> {
+        if let Some(crossworld) = self.is_linkshell_crossworld(for_linkshell_id) {
+            use schema::linkshell_members::dsl::*;
+            if let Ok(members) = linkshell_members
+                .select(models::LinkshellMembers::as_select())
+                .filter(linkshell_id.eq(for_linkshell_id as i64))
+                .load(&mut self.connection)
+            {
+                if (crossworld && members.len() >= CWLS_MAX_MEMBERS)
+                    || (!crossworld && members.len() >= LWLS_MAX_MEMBERS)
+                {
+                    return Some(true);
+                } else {
+                    return Some(false);
+                }
+            }
+        }
+        None
+    }
+
+    // TODO: Change return type from a bool to a LogMessageType so the ZoneConnection can tell the client what happened.
     pub fn add_member_to_linkshell(
         &mut self,
         for_linkshell_id: i64,

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -3125,27 +3125,40 @@ async fn process_packet(
                             linkshell_id,
                             content_id,
                         } => {
-                            connection
+                            let result = connection
                                 .invite_to_linkshell(*content_id, *linkshell_id)
                                 .await;
+
+                            if result != LogMessageType::Default {
+                                connection.send_linkshell_error(result).await;
+                            }
                         }
                         ClientZoneIpcData::LinkshellInviteReply {
                             linkshell_id,
                             response,
-                        } => match response {
-                            LinkshellInviteResponse::Accepted => {
-                                connection.accepted_linkshell_invite(*linkshell_id).await
-                            }
-                            LinkshellInviteResponse::Declined => {
+                        } => {
+                            // Guard against bogus replies by checking if the client is in the shell or not. Invitees are considered actual members, but they just can't receive chat messages.
+                            if connection.is_in_linkshell(*linkshell_id).await {
+                                match response {
+                                    LinkshellInviteResponse::Accepted => {
+                                        connection.accepted_linkshell_invite(*linkshell_id).await
+                                    }
+                                    LinkshellInviteResponse::Declined => {
+                                        connection
+                                            .remove_linkshell_member(
+                                                *linkshell_id,
+                                                connection.player_data.character.content_id as u64,
+                                                CWLSLeaveReason::DeclinedInvite,
+                                            )
+                                            .await
+                                    }
+                                }
+                            } else {
                                 connection
-                                    .remove_linkshell_member(
-                                        *linkshell_id,
-                                        connection.player_data.character.content_id as u64,
-                                        CWLSLeaveReason::DeclinedInvite,
-                                    )
-                                    .await
+                                    .send_linkshell_error(LogMessageType::UnableToAcceptLSInvite)
+                                    .await;
                             }
-                        },
+                        }
                         ClientZoneIpcData::RequestMailbox { unk1, .. } => {
                             connection.send_letter_previews(*unk1).await;
                         }

--- a/servers/world/src/zone_connection/linkshell.rs
+++ b/servers/world/src/zone_connection/linkshell.rs
@@ -28,7 +28,7 @@ impl ZoneConnection {
         )
     }
 
-    async fn is_in_linkshell(&mut self, for_linkshell_id: u64) -> bool {
+    pub async fn is_in_linkshell(&mut self, for_linkshell_id: u64) -> bool {
         let mut db = self.database.lock();
         db.is_in_linkshell(
             self.player_data.character.content_id as u64,
@@ -139,7 +139,20 @@ impl ZoneConnection {
         self.send_ipc_self(ipc).await;
     }
 
-    pub async fn invite_to_linkshell(&mut self, target_content_id: u64, linkshell_id: u64) {
+    pub async fn send_linkshell_error(&mut self, message: LogMessageType) {
+        let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::ShowLinkshellError {
+            log_message: message as u16,
+            unk: 0,
+        });
+
+        self.send_ipc_self(ipc).await;
+    }
+
+    pub async fn invite_to_linkshell(
+        &mut self,
+        target_content_id: u64,
+        linkshell_id: u64,
+    ) -> LogMessageType {
         let successful_invite;
         let target_actor_id;
         let target_name;
@@ -151,7 +164,11 @@ impl ZoneConnection {
                 self.player_data.character.content_id as u64,
                 linkshell_id,
             ) else {
-                return;
+                tracing::error!(
+                    "Unable to determine player {}'s permissions for linkshell {linkshell_id}! Rejecting request!",
+                    self.player_data.character.content_id as u64
+                );
+                return LogMessageType::UnableToInviteToCWLS;
             };
 
             if our_perms < CWLSPermissionRank::Leader {
@@ -160,17 +177,60 @@ impl ZoneConnection {
                     self.player_data.character.content_id as u64,
                     target_content_id
                 );
-                return;
+                return LogMessageType::UnableToInviteToCWLS;
             }
+
+            let Some(target_ids) = db.find_character_ids(Some(target_content_id), None) else {
+                return LogMessageType::UnableToInviteToCWLS;
+            };
+
+            // If the target is already in this linkshell, report as such to the inviter. No need to log a warn or error for this, it's not an error state.
+            if db.is_in_linkshell(target_content_id, linkshell_id) {
+                return LogMessageType::PlayerAlreadyInYourCWLS;
+            }
+
+            // Next, see how many shells the target is in, and don't continue if they're in too many.
+            let linkshell_count =
+                if let Some(linkshells) = db.find_linkshells(target_content_id as i64) {
+                    linkshells
+                        .iter()
+                        .filter(|shell| shell.ids.linkshell_id != 0)
+                        .count()
+                } else {
+                    0
+                };
+
+            if linkshell_count >= CrossworldLinkshell::COUNT {
+                tracing::info!(
+                    "{} tried to invite {} to linkshell {linkshell_id}, but the invitee cannot join any more linkshells! Rejecting request!",
+                    self.player_data.character.content_id as u64,
+                    target_content_id
+                );
+                return LogMessageType::PlayerInTooManyCWLSes;
+            }
+
+            // Then check if the target linkshell is full.
+            let Some(linkshell_full) = db.is_linkshell_full(linkshell_id) else {
+                tracing::error!(
+                    "invite_to_linkshell: Unable to determine if the linkshell is full! Rejecting request!"
+                );
+                return LogMessageType::UnableToInviteToCWLS;
+            };
+
+            if linkshell_full {
+                tracing::info!(
+                    "{} tried to invite {} to linkshell {linkshell_id}, but the linkshell is full! Rejecting request!",
+                    self.player_data.character.content_id as u64,
+                    target_content_id
+                );
+                return LogMessageType::CWLSIsFull;
+            }
+
             successful_invite = db.add_member_to_linkshell(
                 linkshell_id as i64,
                 target_content_id as i64,
                 CWLSPermissionRank::Invitee,
             );
-
-            let Some(target_ids) = db.find_character_ids(Some(target_content_id), None) else {
-                return;
-            };
 
             target_actor_id = target_ids.actor_id;
             target_name = target_ids.name;
@@ -199,14 +259,10 @@ impl ZoneConnection {
                 .send(ToServer::SendLinkshellInvite(target_actor_id, ipc))
                 .await;
         } else {
-            let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::ShowLinkshellError {
-                // TODO: Probably display other errors if some other error occurs while adding the member. For now, add_member_to_linkshell only returns a bool...
-                log_message: LogMessageType::PlayerAlreadyInYourCWLS as u16,
-                unk: 0,
-            });
-
-            self.send_ipc_self(ipc).await;
+            return LogMessageType::UnableToInviteToCWLS;
         }
+
+        LogMessageType::Default
     }
 
     pub async fn received_linkshell_invite(&mut self, invite_info: CrossworldLinkshellInvite) {


### PR DESCRIPTION
-Reject invite requests if the invitee is in too many linkshells
-Reject invite requests if the target linkshell is full
-Present the inviter with error messages in more situations
-Reject invite replies from the invitee if they haven't been invited to that LS

With the advent of the "Organize CWLS" feature, it made sense to go ahead and do this, since it's something we're not interested in at this current time.