### PR TITLE
Implement initial support for party teleport sharing

### DIFF
--- a/core/src/ipc/zone/server/actor_control.rs
+++ b/core/src/ipc/zone/server/actor_control.rs
@@ -356,10 +356,10 @@ pub enum ActorControlCategory {
     /// The player is offered a teleport by someone in their party.
     #[brw(magic = 204u32)]
     TeleportOffered {
-        /// If the player is inelligible for this teleport, it'll be set to true.
+        /// If the player is ineligible for this teleport, it'll be set to true.
         #[br(map = read_bool_from::<u32>)]
         #[bw(map = write_bool_as::<u32>)]
-        inelligible_for_teleport: bool,
+        ineligible_for_teleport: bool,
         /// The destination aetheryte.
         aetheryte_id: u32,
         /// The party member who offered the teleport. It only affects the name of the offerer, getting it wrong shows either the wrong name or no name at all.

--- a/servers/world/src/common.rs
+++ b/servers/world/src/common.rs
@@ -8,7 +8,12 @@ use std::{
 
 use tokio::sync::mpsc::Sender;
 
-use crate::{StatusEffects, lua::LuaTask, server::Party, zone_connection::BaseParameters};
+use crate::{
+    StatusEffects,
+    lua::LuaTask,
+    server::Party,
+    zone_connection::{BaseParameters, TeleportQuery},
+};
 use kawari::{
     common::{
         CharacterMode, ContainerType, JumpState, LegacyEquipmentModelId, LogMessageType,
@@ -233,6 +238,8 @@ pub enum FromServer {
     FurniturePlaced(ContainerType, u16, u16, u8, Position, bool, f32, u8),
     /// Inform the client that another player has moved or rotated a piece of furniture.
     FurnitureTranslated((bool, u8), u16, Position, f32, bool),
+    /// Inform the client that another player in their party has offered them a teleport.
+    TeleportOffered(u32, TeleportQuery),
 }
 
 #[derive(Debug, Clone)]
@@ -474,6 +481,8 @@ pub enum ToServer {
     ),
     /// The client moves or rotates a piece of furniture.
     TranslateFurniture(ObjectId, (bool, u8), u16, Position, f32, bool),
+    /// The client offers a teleport to nearby party members.
+    OfferTeleportToParty(Option<u64>, ObjectId, u16, TeleportQuery),
 }
 
 #[derive(Clone, Debug)]

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -180,6 +180,7 @@ async fn initial_setup(
                     mail_results: Vec::new(),
                     mail_index: 0,
                     spawned_in: false,
+                    offered_teleport: None,
                 };
 
                 // Handle setup before passing off control to the zone connection.
@@ -1711,6 +1712,21 @@ async fn process_packet(
                                             },
                                         ))
                                         .await;
+                                }
+                                ClientTriggerCommand::TeleportOfferReply { decline_teleport } => {
+                                    if !decline_teleport
+                                        && let Some(offered_teleport) = &connection.offered_teleport
+                                    {
+                                        connection
+                                            .warp_aetheryte(
+                                                offered_teleport.aetheryte_id as u32,
+                                                false,
+                                                true,
+                                            )
+                                            .await;
+                                    } else {
+                                        connection.offered_teleport = None;
+                                    }
                                 }
                                 _ => {
                                     // inform the server of our trigger, it will handle sending it to other clients
@@ -3653,6 +3669,30 @@ async fn process_server_msg(
                     )
                     .await;
                 lua_player.zone_data = lua_zone;
+            }
+            FromServer::TeleportOffered(party_member_index, teleport_info) => {
+                // By default, don't allow the player to go.
+                let mut ineligible_for_teleport = true;
+                let aetheryte_id = teleport_info.aetheryte_id as u32;
+
+                // If the player has this destination unlocked and has no previously offered teleport, they can go too.
+                let unlocked = connection
+                    .player_data
+                    .aetheryte
+                    .unlocked
+                    .contains(aetheryte_id);
+                if unlocked && connection.offered_teleport.is_none() {
+                    connection.offered_teleport = Some(teleport_info);
+                    ineligible_for_teleport = false;
+                }
+
+                connection
+                    .actor_control_self(ActorControlCategory::TeleportOffered {
+                        ineligible_for_teleport,
+                        aetheryte_id,
+                        party_member_index,
+                    })
+                    .await;
             }
             FromServer::SocialInvite(
                 sender_account_id,

--- a/servers/world/src/server/party.rs
+++ b/servers/world/src/server/party.rs
@@ -1348,6 +1348,55 @@ pub fn handle_party_messages(
             network.send_to_party(*party_id, None, msg, DestinationNetwork::ZoneClients);
             true
         }
+        ToServer::OfferTeleportToParty(party_id, from_actor_id, from_zone_id, teleport_info) => {
+            let Some(party_id) = party_id else {
+                return true;
+            };
+
+            let mut network = network.lock();
+
+            // We're going to offer this teleport only to people in the same area.
+            let mut members_in_same_zone = Vec::new();
+
+            // We're interested in the offeror's index into the party so their name will display correctly for other party members.
+            let mut offeror_index = None;
+            {
+                let data = data.lock();
+                let the_party = network.parties.entry(*party_id).or_default();
+
+                for (member_index, member) in the_party.members.iter().enumerate() {
+                    if member.actor_id == *from_actor_id {
+                        offeror_index = Some(member_index as u32);
+                        continue; // Don't add ourself to the same-zone list
+                    }
+
+                    // If we can't find their instance for some reason, just skip to the next member
+                    let Some(instance) = data.find_actor_instance(member.actor_id) else {
+                        continue;
+                    };
+
+                    // No point collecting them if they're offline.
+                    if member.is_online() && (instance.zone.id == *from_zone_id) {
+                        members_in_same_zone.push(member.actor_id);
+                    }
+                }
+            }
+
+            let Some(offeror_index) = offeror_index else {
+                return true;
+            };
+
+            let msg = FromServer::TeleportOffered(offeror_index, teleport_info.clone());
+            for member_actor_id in members_in_same_zone {
+                network.send_to_by_actor_id(
+                    member_actor_id,
+                    msg.clone(),
+                    DestinationNetwork::ZoneClients,
+                );
+            }
+
+            true
+        }
         _ => false,
     }
 }

--- a/servers/world/src/zone_connection/lua.rs
+++ b/servers/world/src/zone_connection/lua.rs
@@ -118,7 +118,8 @@ impl ZoneConnection {
                     aetheryte_id,
                     housing_aethernet,
                 } => {
-                    self.warp_aetheryte(*aetheryte_id, *housing_aethernet).await;
+                    self.warp_aetheryte(*aetheryte_id, *housing_aethernet, false)
+                        .await;
                 }
                 LuaTask::ToggleInvisibility { invisible } => {
                     self.toggle_invisibility(*invisible).await;
@@ -674,7 +675,7 @@ impl ZoneConnection {
                     .await;
                 }
                 LuaTask::ReturnToHomepoint {} => {
-                    self.warp_aetheryte(self.player_data.aetheryte.homepoint as u32, false)
+                    self.warp_aetheryte(self.player_data.aetheryte.homepoint as u32, false, false)
                         .await;
                 }
                 LuaTask::JoinContent { id } => {

--- a/servers/world/src/zone_connection/mod.rs
+++ b/servers/world/src/zone_connection/mod.rs
@@ -190,6 +190,8 @@ pub struct ZoneConnection {
     pub mail_index: usize,
     /// Whether the player is spawned in or not.
     pub spawned_in: bool,
+    /// The last teleport offered to this player. Only one can be kept at a time.
+    pub offered_teleport: Option<TeleportQuery>,
 }
 
 impl ZoneConnection {

--- a/servers/world/src/zone_connection/zone.rs
+++ b/servers/world/src/zone_connection/zone.rs
@@ -4,6 +4,7 @@ use crate::{
     ObsfucationData, TeleportReason, ToServer, ZoneConnection,
     inventory::BuyBackList,
     lua::{LuaContent, LuaZone},
+    zone_connection::TeleportQuery,
 };
 use kawari::{
     common::{
@@ -176,6 +177,8 @@ impl ZoneConnection {
 
             if !bound_by_duty {
                 flags |= ZoneInitFlags::ENABLE_FLYING;
+            } else {
+                self.offered_teleport = None; // Discard any previously offered teleports once we're in a duty.
             }
 
             let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::ZoneInit(ZoneInit {
@@ -476,7 +479,12 @@ impl ZoneConnection {
             .await;
     }
 
-    pub async fn warp_aetheryte(&mut self, aetheryte_id: u32, housing_aethernet: bool) {
+    pub async fn warp_aetheryte(
+        &mut self,
+        aetheryte_id: u32,
+        housing_aethernet: bool,
+        taking_offered_teleport: bool,
+    ) {
         self.teleport_reason = TeleportReason::Aetheryte;
         self.handle
             .send(ToServer::WarpAetheryte(
@@ -486,6 +494,25 @@ impl ZoneConnection {
                 housing_aethernet,
             ))
             .await;
+
+        if self.party_id != 0 && !housing_aethernet && !taking_offered_teleport {
+            let teleport_info = TeleportQuery {
+                aetheryte_id: aetheryte_id as u16,
+            };
+
+            self.handle
+                .send(ToServer::OfferTeleportToParty(
+                    Some(self.party_id),
+                    self.player_data.character.actor_id,
+                    self.player_data.volatile.zone_id as u16,
+                    teleport_info,
+                ))
+                .await;
+        }
+
+        if taking_offered_teleport {
+            self.offered_teleport = None;
+        }
     }
 
     pub async fn change_weather(&mut self, new_weather_id: u8) {


### PR DESCRIPTION
This PR adds initial support for sharing teleports with party members in the same area as the sender. Receiving players' ZoneConnections will also check if they're allowed to use this teleport by checking for aetheryte unlock status, as well as previously offered teleports. If they're storing a previously unused teleport, then that player will not be considered eligible to get a new one until they discard the previous one (either by responding to the offer, going offline, or entering a duty).