### PR TITLE
Fix trade softlocking by implementing more of the sequence

### DIFF
--- a/core/src/ipc/zone/client/mod.rs
+++ b/core/src/ipc/zone/client/mod.rs
@@ -387,7 +387,11 @@ pub enum ClientZoneIpcData {
         handler_id: HandlerId,
     },
     Trade {
-        unk: [u8; 16],
+        sequence: u16,
+        unk1: u16, // Some value echoed back to the client
+        unk2: u32, // Observed as 1 when beginning a trade, and 7 when doing the second trade opcode
+        target_actor_id: ObjectId,
+        unk3: [u8; 4],
     },
     ShareStrategyBoard {
         /// When the content id is 0, the client is starting a non-real-time session, or is initiating one but isn't ready yet.

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -181,6 +181,7 @@ async fn initial_setup(
                     mail_index: 0,
                     spawned_in: false,
                     offered_teleport: None,
+                    is_trading: false,
                 };
 
                 // Handle setup before passing off control to the zone connection.
@@ -2786,8 +2787,25 @@ async fn process_packet(
                                 event.0.on_enter_territory(&event.1, lua_player).await;
                             }
                         }
-                        ClientZoneIpcData::Trade { .. } => {
-                            tracing::info!("Trading is unimplemented");
+                        ClientZoneIpcData::Trade { sequence, unk1, .. } => {
+                            // TODO: This needs a lot more research, but it's good enough for now to act as a stub to prevent client softlocks
+                            // When trading, the client sends the trade opcode twice for unknown (at this time) reasons, so we need to keep track of where we're at in the sequence
+                            let action_type;
+                            if !connection.is_trading {
+                                tracing::info!("Trading is unimplemented");
+                                action_type = 0x1607; // Some ack to let the client proceed with the trade sequence
+                                connection.is_trading = true;
+                            } else {
+                                action_type = 0x207; // Some ack to tell the client that the target can't trade at this time
+                                connection.is_trading = false;
+                            }
+
+                            connection
+                                .send_inventory_ack(
+                                    ((*unk1 as u32) << 16) | *sequence as u32,
+                                    action_type,
+                                )
+                                .await;
                         }
                         ClientZoneIpcData::ShareStrategyBoard {
                             content_id,

--- a/servers/world/src/zone_connection/mod.rs
+++ b/servers/world/src/zone_connection/mod.rs
@@ -192,6 +192,8 @@ pub struct ZoneConnection {
     pub spawned_in: bool,
     /// The last teleport offered to this player. Only one can be kept at a time.
     pub offered_teleport: Option<TeleportQuery>,
+    /// Whether the player is trading with another player or not.
+    pub is_trading: bool,
 }
 
 impl ZoneConnection {


### PR DESCRIPTION
-Trading is not yet implemented, it simply displays an error message saying that the recipient cannot trade at the current time.