### PR TITLE
Revert removal of SearchUIGrandCompanies::NONE special-casing

### DIFF
--- a/core/src/ipc/zone/search_info.rs
+++ b/core/src/ipc/zone/search_info.rs
@@ -38,6 +38,11 @@ bitflags! {
 
 impl std::fmt::Debug for SearchUIGrandCompanies {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        // Special-case NONE because it isn't all enabled at once, it's the *absence* of all at once.
+        if *self == SearchUIGrandCompanies::NONE {
+            return write!(f, "NONE");
+        }
+
         bitflags::parser::to_writer(self, f)
     }
 }

--- a/core/src/ipc/zone/search_info.rs
+++ b/core/src/ipc/zone/search_info.rs
@@ -38,7 +38,8 @@ bitflags! {
 
 impl std::fmt::Debug for SearchUIGrandCompanies {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        // Special-case NONE because it isn't all enabled at once, it's the *absence* of all at once.
+        // Special-case NONE because it's 255 and indicates the *absence* of the flags!
+        // NOTE: before considering removal of this, please read the above comment!
         if *self == SearchUIGrandCompanies::NONE {
             return write!(f, "NONE");
         }


### PR DESCRIPTION
It *needs* to be special-cased because NONE in this enum/packet is 255, not 0, or PacketAnalyzer will display an erroneous result!

It now incorrectly displays `grand_company: MAELSTROM | ADDERS | FLAMES | NONE`. When it's NONE, it should display `grand_company: NONE`. I'm aware bitflags isn't exactly equipped for that, which is why I special-cased it.