### PR TITLE
Add Spectator-related ACs and packets

### DIFF
--- a/core/src/ipc/zone/server/actor_control.rs
+++ b/core/src/ipc/zone/server/actor_control.rs
@@ -933,6 +933,15 @@ pub enum ActorControlCategory {
         unk4: u32,
     },
 
+    // TODO: There's a lot more spectator-related ACs
+    /// Initializes the SpectatorManager on the client.
+    #[brw(magic = 1600u32)]
+    InitializeSpectatorManager { row_id: u32, unk2: u32, unk3: u32 },
+
+    /// This actually shows the Spectator UI.
+    #[brw(magic = 1607u32)]
+    ShowSpectatorUI {},
+
     /// Calls some method in PvPProfile, unsure what it does yet.
     #[brw(magic = 1610u32)]
     UnkPvPProfileRelated {

--- a/core/src/ipc/zone/server/mod.rs
+++ b/core/src/ipc/zone/server/mod.rs
@@ -1575,6 +1575,11 @@ pub enum ServerZoneIpcData {
     OccultCrescentSetup {
         unk1: [u8; 160],
     },
+    SpectatorList {
+        object_ids: [ObjectId; 8],
+        #[brw(pad_after = 3)] // padding
+        unk1: u8,
+    },
 }
 
 #[cfg(test)]

--- a/resources/data/opcodes.yml
+++ b/resources/data/opcodes.yml
@@ -771,6 +771,10 @@ ServerZoneIpcType:
   comment: Pops open the custom UI for Occult Crescent among other things. Unsure if used for other public content.
   opcode: 690
   size: 160
+- name: SpectatorList
+  comment: When sent, populates the spectator list for Crystalline Conflict matches. This is visible in the Duty Menu and the Spectator UI.
+  opcode: 944
+  size: 36
 ClientZoneIpcType:
 - name: InitRequest
   comment: Sent by the client when they successfully initialize with the server, and they need several bits of information (e.g. what zone to load.)

--- a/servers/world/src/zone_connection/zone.rs
+++ b/servers/world/src/zone_connection/zone.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use kawari::{
     common::{
-        FestivalId, HandlerId, HandlerType, HouseId, HouseUnit, HousingFlag, LandData, Position,
-        PublicContentType, WarpType, timestamp_secs,
+        FestivalId, HandlerId, HandlerType, HouseId, HouseUnit, HousingFlag, LandData, ObjectId,
+        Position, PublicContentType, WarpType, timestamp_secs,
     },
     config::get_config,
     constants::OBFUSCATION_ENABLED_MODE,
@@ -749,5 +749,23 @@ impl ZoneConnection {
                 .await;
             }
         }
+
+        // TODO: temporary, don't send in all instances
+        self.send_ipc_self(ServerZoneIpcSegment::new(
+            ServerZoneIpcData::SpectatorList {
+                object_ids: [
+                    self.player_data.character.actor_id,
+                    ObjectId::default(),
+                    ObjectId::default(),
+                    ObjectId::default(),
+                    ObjectId::default(),
+                    ObjectId::default(),
+                    ObjectId::default(),
+                    ObjectId::default(),
+                ],
+                unk1: 1,
+            },
+        ))
+        .await;
     }
 }


### PR DESCRIPTION
Used in Crystalline Conflict custom matches and stuff. We don't have a debug command for this yet.