### PR TITLE
Housing: update the amount of items sent when spawning in as an observer

### DIFF
--- a/servers/world/src/zone_connection/zone.rs
+++ b/servers/world/src/zone_connection/zone.rs
@@ -353,10 +353,10 @@ impl ZoneConnection {
 
             // Finally, populate the exterior furniture.
             // TODO: Actually send some real furniture, once we can do that!
-            for index in 0..8 {
+            for index in 0..15 {
                 self.send_ipc_self(ServerZoneIpcSegment::new(ServerZoneIpcData::FurnitureList(
                     FurnitureList {
-                        count: 8,
+                        count: 15,
                         index,
                         ..Default::default()
                     },
@@ -373,27 +373,30 @@ impl ZoneConnection {
             ))
             .await;
 
-            // The LandId is currently set so that plugins like HousingPos/Buildingway can plop stuff down
-            self.send_ipc_self(ServerZoneIpcSegment::new(ServerZoneIpcData::FurnitureList(
-                FurnitureList {
-                    id: HouseId {
-                        unit: HouseUnit {
-                            apartment_division_plot_index: 0,
-                            apartment_flag: true,
+            // TODO: Limit this by interior size once we have furniture persistence
+            for index in 0..6 {
+                // The LandId is currently set so that plugins like HousingPos/Buildingway can plop stuff down
+                self.send_ipc_self(ServerZoneIpcSegment::new(ServerZoneIpcData::FurnitureList(
+                    FurnitureList {
+                        id: HouseId {
+                            unit: HouseUnit {
+                                apartment_division_plot_index: 0,
+                                apartment_flag: true,
+                            },
+                            unk1: 0,
+                            room_number: 1,
+                            ward_index: 0,
+                            territory_type_id: 340,
+                            world_id: config.world.world_id,
                         },
-                        unk1: 0,
-                        room_number: 1,
-                        ward_index: 0,
-                        territory_type_id: 340,
-                        world_id: config.world.world_id,
+                        count: 1,
+                        index,
+                        unk2: 100, // Indoors
+                        ..Default::default()
                     },
-                    count: 1,
-                    index: 0,
-                    unk2: 100, // Indoors
-                    ..Default::default()
-                },
-            )))
-            .await;
+                )))
+                .await;
+            }
         }
 
         self.conditions

--- a/servers/world/src/zone_connection/zone.rs
+++ b/servers/world/src/zone_connection/zone.rs
@@ -389,7 +389,7 @@ impl ZoneConnection {
                             territory_type_id: 340,
                             world_id: config.world.world_id,
                         },
-                        count: 1,
+                        count: 6,
                         index,
                         unk2: 100, // Indoors
                         ..Default::default()


### PR DESCRIPTION
-The housing item expansion increased the amount of exterior furniture list packets from 8 to 15
-I increased the amount of interior furniture list packets sent from 1 to 6 so makeplace/housingpos can spawn an entire housing preview instead of just 100 items. Later we can limit it once we have item persistence and should actually care about how many items should be in a given housing zone.

I titled this "as an observer" to clarify that it won't let you spawn additional items via in-game means. This is still purely for housing preview plugins.