### PR TITLE
Add basic support for friend groups (icons in the friend list)

### DIFF
--- a/core/src/ipc/zone/social_list.rs
+++ b/core/src/ipc/zone/social_list.rs
@@ -134,7 +134,7 @@ impl diesel::deserialize::FromSql<diesel::sql_types::Integer, diesel::sqlite::Sq
     }
 }
 
-// TODO: This seems to actually be entirely wrong, or at least reused for friend group icons in the context of the friend list, we need to rethink this eventully
+// TODO: Rename the ICON_* consts if we discover other places they're reused
 /// Flags to enable or disable various things in the Social Menu UI.
 #[binrw]
 #[derive(Clone, Copy, Default, Eq, PartialEq)]
@@ -142,11 +142,13 @@ pub struct SocialListUIFlags(u16);
 
 bitflags! {
     impl SocialListUIFlags: u16 {
-        /// The player data was unable to be retrieved (deleted, on another datacenter (?), some other issue).
-        const UNABLE_TO_RETRIEVE = 1;
-        const UNKNOWN_2 = 2;
-        const UNKNOWN_4 = 4;
-        const UNKNOWN_256 = 256;
+        const ICON_STAR = 1;
+        const ICON_CIRCLE = 2;
+        const ICON_TRIANGLE = 3;
+        const ICON_DIAMOND = 4;
+        const ICON_HEART = 5;
+        const ICON_SPADE = 6;
+        const ICON_CLUB = 7;
         /// Enables the right-click context menu for this PlayerEntry.
         const ENABLE_CONTEXT_MENU = 4096;
     }
@@ -234,10 +236,10 @@ pub struct SocialList {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct FriendGroupIconInfo {
     /// The friend's content id.
-    content_id: u64,
+    pub content_id: u64,
     /// The desired group icon. 0 is no icon, and 1-7 correspond to the desired symbols.
-    #[brw(pad_after = 4)] // empty
-    icon: u32, // TODO: This is actually SocialListUIFlags, but we need to rework that first
+    #[brw(pad_after = 6)] // empty
+    pub icon: SocialListUIFlags,
 }
 
 #[cfg(test)]

--- a/servers/world/src/database/friends.rs
+++ b/servers/world/src/database/friends.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 
 use super::{Friends, WorldDatabase, schema::friends::dsl::*};
 use crate::GameData;
-use kawari::ipc::zone::PlayerEntry;
+use kawari::ipc::zone::{PlayerEntry, SocialListUIFlags};
 
 impl WorldDatabase {
     fn get_friend_content_ids(&mut self, for_content_id: i64) -> Vec<i64> {
@@ -100,6 +100,7 @@ impl WorldDatabase {
         for their_content_id in friend_content_ids {
             let mut friend_entry = self.get_player_entry(game_data, their_content_id);
             friend_entry.timestamp = self.get_friend_timestamp(for_content_id, their_content_id);
+            friend_entry.ui_flags |= self.get_friend_group_icon(for_content_id, their_content_id);
             friend_entries.push(friend_entry);
         }
         friend_entries
@@ -113,5 +114,33 @@ impl WorldDatabase {
             .first::<i64>(&mut self.connection)
             .unwrap_or_default();
         time as u32
+    }
+
+    pub fn set_friend_group_icon(
+        &mut self,
+        for_content_id: i64,
+        for_friend_content_id: i64,
+        icon: SocialListUIFlags,
+    ) {
+        diesel::update(friends)
+            .filter(content_id.eq(for_content_id))
+            .filter(friend_content_id.eq(for_friend_content_id))
+            .set(group_icon.eq(icon.bits() as i32))
+            .execute(&mut self.connection)
+            .unwrap();
+    }
+
+    fn get_friend_group_icon(
+        &mut self,
+        for_content_id: i64,
+        for_friend_content_id: i64,
+    ) -> SocialListUIFlags {
+        let icon = friends
+            .select(group_icon)
+            .filter(content_id.eq(for_content_id))
+            .filter(friend_content_id.eq(for_friend_content_id))
+            .first::<i32>(&mut self.connection)
+            .unwrap_or_default();
+        SocialListUIFlags::from_bits_truncate(icon as u16)
     }
 }

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -3074,8 +3074,8 @@ async fn process_packet(
                                 });
                             connection.send_ipc_self(ipc).await;
                         }
-                        ClientZoneIpcData::SetFriendGroupIcon { .. } => {
-                            tracing::warn!("Setting friend group icons is unimplemented");
+                        ClientZoneIpcData::SetFriendGroupIcon(icon_info) => {
+                            connection.set_friend_group_icon(icon_info).await;
                         }
                         ClientZoneIpcData::CreateLocalLinkshellRequest { .. } => {
                             tracing::warn!("Creating local linkshells is unimplemented");

--- a/servers/world/src/zone_connection/friends.rs
+++ b/servers/world/src/zone_connection/friends.rs
@@ -2,7 +2,7 @@
 use crate::{ToServer, ZoneConnection};
 use kawari::{
     common::ObjectId,
-    ipc::zone::{ServerZoneIpcData, ServerZoneIpcSegment},
+    ipc::zone::{FriendGroupIconInfo, ServerZoneIpcData, ServerZoneIpcSegment},
 };
 impl ZoneConnection {
     pub async fn refresh_friend_list(&mut self) {
@@ -68,6 +68,20 @@ impl ZoneConnection {
             unk1: 1,
         });
 
+        self.send_ipc_self(ipc).await;
+    }
+
+    pub async fn set_friend_group_icon(&mut self, icon_info: &FriendGroupIconInfo) {
+        {
+            let mut db = self.database.lock();
+            db.set_friend_group_icon(
+                self.player_data.character.content_id,
+                icon_info.content_id as i64,
+                icon_info.icon,
+            );
+        }
+
+        let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::FriendGroupIcon(icon_info.clone()));
         self.send_ipc_self(ipc).await;
     }
 }


### PR DESCRIPTION
This PR implements friend group icons, allowing players to organize their friends by groups. This stuff was basically already supported, it just needed to be hooked up. :)