### PR TITLE
Don't offer teleports to other players when using the aethernet

### DIFF
--- a/servers/world/src/common.rs
+++ b/servers/world/src/common.rs
@@ -237,6 +237,8 @@ pub enum FromServer {
     PlayInitialCutscene(u32, u32),
     /// A FATE was completed. This is meant to track SHARED FATE completion and not much else yet.
     FATEComplete,
+    /// Instruct the client's zone connection to check if the teleport can be shared.
+    CheckTeleportSharingEligibility(u32),
 }
 
 #[derive(Debug, Clone)]

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -191,6 +191,7 @@ async fn initial_setup(
                     initial_login: true,
                     fate_motivation_npcs: HashMap::new(),
                     content_handler_id: None,
+                    can_share_teleport: false,
                 };
 
                 // Handle setup before passing off control to the zone connection.
@@ -4293,6 +4294,9 @@ async fn process_server_msg(
             }
             FromServer::FATEComplete => {
                 connection.record_fate_completion();
+            }
+            FromServer::CheckTeleportSharingEligibility(aetheryte_id) => {
+                connection.check_tele_sharing_eligibility(aetheryte_id);
             }
             _ => {
                 tracing::error!(

--- a/servers/world/src/server/mod.rs
+++ b/servers/world/src/server/mod.rs
@@ -1255,6 +1255,9 @@ pub async fn server_main_loop(
                             {
                                 let mut network = network.lock();
                                 network.send_to(from_id, msg, DestinationNetwork::ZoneClients);
+                                let msg =
+                                    FromServer::CheckTeleportSharingEligibility(*aetheryte_id);
+                                network.send_to(from_id, msg, DestinationNetwork::ZoneClients);
                             }
 
                             let mut data = data.lock();

--- a/servers/world/src/zone_connection/mod.rs
+++ b/servers/world/src/zone_connection/mod.rs
@@ -206,6 +206,8 @@ pub struct ZoneConnection {
     pub fate_motivation_npcs: HashMap<ObjectId, u16>,
     /// Used only for the local player's PlayerSpawn.
     pub content_handler_id: Option<HandlerId>,
+    /// Whether the player can offer this teleport to their party.
+    pub can_share_teleport: bool, // TODO: remove this and add more teleport reasons
 }
 
 impl ZoneConnection {
@@ -513,5 +515,15 @@ impl ZoneConnection {
             });
             self.send_ipc_self(ipc).await;
         }
+    }
+
+    pub fn check_tele_sharing_eligibility(&mut self, aetheryte_id: u32) {
+        let mut gamedata = self.gamedata.lock();
+        // The teleport can only be offered if it's a town aetheryte (not shard) and the player is actually teleporting, not using the aethernet.
+        self.can_share_teleport = gamedata.is_aetheryte(aetheryte_id);
+    }
+
+    pub fn can_offer_teleport(&self) -> bool {
+        self.party_id != 0 && self.can_share_teleport
     }
 }

--- a/servers/world/src/zone_connection/zone.rs
+++ b/servers/world/src/zone_connection/zone.rs
@@ -445,7 +445,7 @@ impl ZoneConnection {
             ))
             .await;
 
-        if self.party_id != 0 && !housing_aethernet && !taking_offered_teleport {
+        if self.can_offer_teleport() {
             let teleport_info = TeleportQuery {
                 aetheryte_id: aetheryte_id as u16,
             };
@@ -458,6 +458,8 @@ impl ZoneConnection {
                     teleport_info,
                 ))
                 .await;
+            // Reset it so we don't inadvertently share an invalid aetheryte (housing/city aethernet shard)
+            self.can_share_teleport = false;
         }
 
         if taking_offered_teleport {


### PR DESCRIPTION
In the future, we should consider adding more teleport reasons (or something along those lines) to clean this up a bit, but for now it should eliminate most cases of incorrectly offering aethernet shard warps to party members.