### PR TITLE
Fill out more DirectorPopupMessage

### DIFF
--- a/core/src/ipc/zone/server/mod.rs
+++ b/core/src/ipc/zone/server/mod.rs
@@ -869,18 +869,22 @@ pub enum ServerZoneIpcData {
         starter_name: String,
     },
     DirectorPopupMessage {
-        unk1: u64, // Empty?
+        unk1: ObjectTypeId, // Sometimes has data, but it's not read by the client.
         /// Should be the ID of the instance's director.
         handler_id: HandlerId,
         /// Index into the BNPCName Excel sheet.
         npc_name: u32,
         /// Index into the InstanceContentTextData Excel sheet.
         text_data_id: u32,
-        unk4: u32,
-        unk5: u32,
-        unk6: u32,
-        unk7: u32,
-        unk8: u32,
+        duration_msecs: u32,
+        /// The icon/image that shows on the top left
+        icon: u32,
+        kind: ObjectKind, // Used when resolving npc_name.
+        /// The appearance of the text box.
+        style: u8,
+        #[brw(pad_after = 1)] // padding
+        unk7: u8,
+        unk8: u64,
     },
     DirectorSetupMapEffects64 {
         /// The map effects to setup.


### PR DESCRIPTION
**unk1** was determined to be an **ObjectTypeId** because the client does read this field as an _u64_, and in some instances of this packet (like _Garuda's_ dialogues in _The Howling Eye_) it does have the **ObjectId** in it. Though, it is still "unknown" as, despite as being read and passed, nothing seems to be really done with it?

Valid values for **icon** and **style** can be seen on the **ContentDirectorBattleTalk** sheet.

**unk7** and **unk8** work in conjunction, though what they do isn't fully clear.
**_Client::Game::InstanceContent::ContentDirector_vf43_** is where these values are utilized, as arguments 8 and 7 respectively. There's something going on with an iteration using **unk7**, but that's as far as I can understand.