### PR TITLE
Add initial support for the /dice and /random commands

### DIFF
--- a/core/src/ipc/chat/client/dice_roll.rs
+++ b/core/src/ipc/chat/client/dice_roll.rs
@@ -1,0 +1,46 @@
+use crate::{
+    common::{CHAR_NAME_MAX_LENGTH, read_string, write_string},
+    ipc::chat::ChatChannel,
+};
+use binrw::binrw;
+
+#[binrw]
+#[derive(Clone, Copy, Debug)]
+pub struct ChatDiceRollData {
+    #[brw(pad_after = 7)] // Seemingly empty/padding
+    pub unk1: u8, // Always 1?
+    /// The destination ChatChannel this dice roll should be broadcasted to.
+    pub community_id: ChatChannel,
+    #[brw(pad_after = 7)] // Seemingly empty/padding
+    pub unk2: u8, // Always 3?
+    #[brw(pad_after = 7)] // Seemingly empty/padding
+    pub unk3: u8, // Might be an index of some sort, but unsure
+    /// The number of sides on the die.
+    #[brw(pad_after = 14)] // Seemingly empty/padding
+    pub num_sides: u16,
+}
+
+#[binrw]
+#[derive(Clone, Debug)]
+pub struct ChatDiceRollResult {
+    /// The destination ChatChannel.
+    pub community_id: ChatChannel,
+    /// The account id of the sender.
+    pub account_id: u64,
+    /// The content id of the sender.
+    pub content_id: u64,
+    /// The world id of the sender.
+    pub world_id: u16,
+    /// The result of the dice roll.
+    pub roll_result: u16,
+    /// The number of sides on the die.
+    pub num_sides: u16,
+    pub unk1: u8, // Seems to echo ChatDiceRollData's unk2?
+    pub unk2: u8, // Seems to echo ChatDiceRollData's unk1? Getting either of these unks wrong results in the client seeingly ignoring our response
+    /// The sending character's name.
+    #[brw(pad_size_to = CHAR_NAME_MAX_LENGTH)]
+    #[br(count = CHAR_NAME_MAX_LENGTH)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    pub character_name: String,
+}

--- a/core/src/ipc/chat/client/dice_roll.rs
+++ b/core/src/ipc/chat/client/dice_roll.rs
@@ -1,11 +1,8 @@
-use crate::{
-    common::{CHAR_NAME_MAX_LENGTH, read_string, write_string},
-    ipc::chat::ChatChannel,
-};
+use crate::ipc::chat::ChatChannel;
 use binrw::binrw;
 
 #[binrw]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ChatDiceRollData {
     #[brw(pad_after = 7)] // Seemingly empty/padding
     pub unk1: u8, // Always 1?
@@ -18,29 +15,4 @@ pub struct ChatDiceRollData {
     /// The number of sides on the die.
     #[brw(pad_after = 14)] // Seemingly empty/padding
     pub num_sides: u16,
-}
-
-#[binrw]
-#[derive(Clone, Debug)]
-pub struct ChatDiceRollResult {
-    /// The destination ChatChannel.
-    pub community_id: ChatChannel,
-    /// The account id of the sender.
-    pub account_id: u64,
-    /// The content id of the sender.
-    pub content_id: u64,
-    /// The world id of the sender.
-    pub world_id: u16,
-    /// The result of the dice roll.
-    pub roll_result: u16,
-    /// The number of sides on the die.
-    pub num_sides: u16,
-    pub unk1: u8, // Seems to echo ChatDiceRollData's unk2?
-    pub unk2: u8, // Seems to echo ChatDiceRollData's unk1? Getting either of these unks wrong results in the client seeingly ignoring our response
-    /// The sending character's name.
-    #[brw(pad_size_to = CHAR_NAME_MAX_LENGTH)]
-    #[br(count = CHAR_NAME_MAX_LENGTH)]
-    #[br(map = read_string)]
-    #[bw(map = write_string)]
-    pub character_name: String,
 }

--- a/core/src/ipc/chat/client/mod.rs
+++ b/core/src/ipc/chat/client/mod.rs
@@ -1,6 +1,9 @@
 use binrw::binrw;
 use kawari_core_macro::opcode_data;
 
+mod dice_roll;
+pub use dice_roll::{ChatDiceRollData, ChatDiceRollResult};
+
 mod send_alliance_message;
 pub use send_alliance_message::SendAllianceMessage;
 
@@ -31,6 +34,8 @@ pub enum ClientChatIpcData {
     GetChannelList { unk: [u8; 8] },
     SendCWLinkshellMessage(SendCWLinkshellMessage),
     SendAllianceMessage(SendAllianceMessage),
+    DiceRollCWLS(ChatDiceRollData),
+    DiceRollParty(ChatDiceRollData),
 }
 
 #[cfg(test)]

--- a/core/src/ipc/chat/client/mod.rs
+++ b/core/src/ipc/chat/client/mod.rs
@@ -2,7 +2,7 @@ use binrw::binrw;
 use kawari_core_macro::opcode_data;
 
 mod dice_roll;
-pub use dice_roll::{ChatDiceRollData, ChatDiceRollResult};
+pub use dice_roll::ChatDiceRollData;
 
 mod send_alliance_message;
 pub use send_alliance_message::SendAllianceMessage;

--- a/core/src/ipc/chat/server/dice_roll_result.rs
+++ b/core/src/ipc/chat/server/dice_roll_result.rs
@@ -1,0 +1,30 @@
+use crate::{
+    common::{CHAR_NAME_MAX_LENGTH, read_string, write_string},
+    ipc::chat::ChatChannel,
+};
+use binrw::binrw;
+
+#[binrw]
+#[derive(Clone, Debug, Default)]
+pub struct ChatDiceRollResult {
+    /// The destination ChatChannel.
+    pub community_id: ChatChannel,
+    /// The account id of the sender.
+    pub account_id: u64,
+    /// The content id of the sender.
+    pub content_id: u64,
+    /// The world id of the sender.
+    pub world_id: u16,
+    /// The result of the dice roll.
+    pub roll_result: u16,
+    /// The number of sides on the die.
+    pub num_sides: u16,
+    pub unk1: u8, // Seems to echo ChatDiceRollData's unk2?
+    pub unk2: u8, // Seems to echo ChatDiceRollData's unk1? Getting either of these unks wrong results in the client seeingly ignoring our response
+    /// The sending character's name.
+    #[brw(pad_size_to = CHAR_NAME_MAX_LENGTH)]
+    #[br(count = CHAR_NAME_MAX_LENGTH)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    pub character_name: String,
+}

--- a/core/src/ipc/chat/server/mod.rs
+++ b/core/src/ipc/chat/server/mod.rs
@@ -2,7 +2,7 @@ use binrw::binrw;
 use kawari_core_macro::opcode_data;
 
 use crate::{
-    ipc::chat::SendCWLinkshellMessage,
+    ipc::chat::{ChatDiceRollResult, SendCWLinkshellMessage},
     opcodes::ServerChatIpcType,
     packet::{IpcSegment, ServerIpcSegmentHeader},
 };
@@ -38,6 +38,7 @@ pub enum ServerChatIpcData {
     CWLinkshellMessage(CWLinkshellMessage),
     AllianceMessage(AllianceMessage),
     AllianceMessageEcho(AllianceMessageEcho),
+    ChatDiceRollResult(ChatDiceRollResult),
 }
 
 #[cfg(test)]

--- a/core/src/ipc/chat/server/mod.rs
+++ b/core/src/ipc/chat/server/mod.rs
@@ -2,7 +2,7 @@ use binrw::binrw;
 use kawari_core_macro::opcode_data;
 
 use crate::{
-    ipc::chat::{ChatDiceRollResult, SendCWLinkshellMessage},
+    ipc::chat::SendCWLinkshellMessage,
     opcodes::ServerChatIpcType,
     packet::{IpcSegment, ServerIpcSegmentHeader},
 };
@@ -18,6 +18,9 @@ pub use party_message::PartyMessage;
 
 mod cwlinkshell_message;
 pub use cwlinkshell_message::CWLinkshellMessage;
+
+mod dice_roll_result;
+pub use dice_roll_result::ChatDiceRollResult;
 
 pub type ServerChatIpcSegment =
     IpcSegment<ServerIpcSegmentHeader<ServerChatIpcType>, ServerChatIpcType, ServerChatIpcData>;

--- a/core/src/ipc/zone/client/client_trigger.rs
+++ b/core/src/ipc/zone/client/client_trigger.rs
@@ -546,6 +546,14 @@ pub enum ClientTriggerCommand {
     #[brw(magic = 3201u32)]
     BeginLoading,
 
+    /// The client rolls an n-sided die with the /random command. If the amount of sides is zero (meaning the player didn't specify any), the server treats it as a 999-sided die.
+    #[brw(magic = 9000u32)]
+    ZoneDiceRoll {
+        // Only the second u32 is used, the others seem unused
+        #[brw(pad_before = 4, pad_after = 12)]
+        num_sides: u32,
+    },
+
     /// The client opens the Mogpendium or interacts with the Retainer Bell.
     #[brw(magic = 9003u32)]
     OpenUnk1 { unk1: u32, unk2: u32 },

--- a/core/src/ipc/zone/server/dice_roll_result.rs
+++ b/core/src/ipc/zone/server/dice_roll_result.rs
@@ -2,7 +2,7 @@ use crate::common::{CHAR_NAME_MAX_LENGTH, ObjectId, read_string, write_string};
 use binrw::binrw;
 
 #[binrw]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ZoneDiceRollResult {
     /// The sender's account id.
     pub account_id: u64,

--- a/core/src/ipc/zone/server/dice_roll_result.rs
+++ b/core/src/ipc/zone/server/dice_roll_result.rs
@@ -1,0 +1,27 @@
+use crate::common::{CHAR_NAME_MAX_LENGTH, ObjectId, read_string, write_string};
+use binrw::binrw;
+
+#[binrw]
+#[derive(Clone, Debug)]
+pub struct ZoneDiceRollResult {
+    /// The sender's account id.
+    pub account_id: u64,
+    /// The sender's content id.
+    pub content_id: u64,
+    /// The sender's actor id.
+    pub actor_id: ObjectId,
+    /// The sender's world id.
+    pub world_id: u16,
+    /// The result of the dice roll.
+    pub roll_result: u16,
+    /// The number of sides the die had.
+    pub num_sides: u16,
+    pub unk: u16, // Always 0x100?
+    /// The sending character's name.
+    #[brw(pad_size_to = CHAR_NAME_MAX_LENGTH)]
+    #[br(count = CHAR_NAME_MAX_LENGTH)]
+    #[br(map = read_string)]
+    #[bw(map = write_string)]
+    #[brw(pad_after = 4)] // Empty/padding
+    pub name: String,
+}

--- a/core/src/ipc/zone/server/mod.rs
+++ b/core/src/ipc/zone/server/mod.rs
@@ -187,6 +187,9 @@ pub use duty_support_information::DutySupportInformation;
 mod walk_in_event;
 pub use walk_in_event::{WalkInEvent, WalkInEventType};
 
+mod dice_roll_result;
+pub use dice_roll_result::ZoneDiceRollResult;
+
 use crate::common::{
     CHAR_NAME_MAX_LENGTH, ContainerType, ItemOperationKind, ObjectId, read_bool_from, read_string,
     write_bool_as, write_string,
@@ -1569,6 +1572,7 @@ pub enum ServerZoneIpcData {
         /// Sets the "N hits" label in the "Search Results" window for the marketboard.
         hits: u32,
     },
+    ZoneDiceRollResult(ZoneDiceRollResult),
 }
 
 #[cfg(test)]

--- a/resources/data/opcodes.yml
+++ b/resources/data/opcodes.yml
@@ -787,6 +787,10 @@ ServerZoneIpcType:
   comment: Sent to populate the hits label in the marketboard.
   opcode: 559
   size: 8
+- name: ZoneDiceRollResult
+  comment: Sent to the client and nearby players after the client sends a dice roll.
+  opcode: 361
+  size: 64
 ClientZoneIpcType:
 - name: InitRequest
   comment: Sent by the client when they successfully initialize with the server, and they need several bits of information (e.g. what zone to load.)
@@ -1287,6 +1291,10 @@ ServerChatIpcType:
   comment: Sent by the server in response to a client sending a private message to the specified crossworld linkshell.
   opcode: 114
   size: 1096
+- name: ChatDiceRollResult
+  comment: Sent in response to various chat connection DiceRoll packets. It's sent to all online members, including the dice roll initiator, of the specified chat mode.
+  opcode: 301
+  size: 64
 ClientChatIpcType:
 - name: SendTellMessage
   comment: Sent by the client when sending a private message to another client.
@@ -1308,6 +1316,14 @@ ClientChatIpcType:
   comment: Sent by the client when sending a message to a cross-world linkshell.
   opcode: 109
   size: 1040
+- name: DiceRollParty
+  comment: Sent by the client to their party or a local linkshell.
+  opcode: 111
+  size: 48
+- name: DiceRollCWLS
+  comment: Sent by the client to their CWLS.
+  opcode: 112
+  size: 48
 CustomIpcType:
 - name: RequestCreateCharacter
   comment: Request the world server to create a character

--- a/servers/world/src/chat_connection.rs
+++ b/servers/world/src/chat_connection.rs
@@ -360,6 +360,24 @@ impl ChatConnection {
         from_actor_id: ObjectId,
         result: ChatDiceRollResult,
     ) {
+        if result.community_id.channel_type == ChatChannelType::CWLinkshell
+            && !self.chatchannels.cwls.contains(&result.community_id)
+        {
+            tracing::error!(
+                "cwls_message_received: We received a dice roll not destined for one of our linkshells, what happened? Discarding result. The destination linkshell was {:#?}",
+                result.community_id
+            );
+            return;
+        } else if result.community_id.channel_type == ChatChannelType::Party
+            && result.community_id.channel_number != self.chatchannels.party.channel_number
+        {
+            tracing::error!(
+                "cwls_message_received: We received a dice roll not destined for our party, what happened? Discarding result. The destination party was {:#?}",
+                result.community_id
+            );
+            return;
+        }
+
         let ipc = ServerChatIpcSegment::new(ServerChatIpcData::ChatDiceRollResult(result));
         self.send_ipc_from(from_actor_id, ipc).await;
     }

--- a/servers/world/src/chat_connection.rs
+++ b/servers/world/src/chat_connection.rs
@@ -4,15 +4,16 @@ use parking_lot::Mutex;
 use tokio::net::TcpStream;
 
 use super::common::ClientId;
-use crate::{ServerHandle, ToServer, WorldDatabase, database::Character};
+use crate::{ServerHandle, ToServer, WorldDatabase, common::roll_die, database::Character};
 use kawari::{
     common::{ObjectId, timestamp_secs},
     config::WorldConfig,
     ipc::{
         chat::{
-            CWLinkshellMessage, ChatChannel, ChatChannelType, ClientChatIpcSegment, PartyMessage,
-            SendCWLinkshellMessage, SendPartyMessage, SendTellMessage, ServerChatIpcData,
-            ServerChatIpcSegment, TellMessage, TellNotFoundError,
+            CWLinkshellMessage, ChatChannel, ChatChannelType, ChatDiceRollData, ChatDiceRollResult,
+            ClientChatIpcSegment, PartyMessage, SendCWLinkshellMessage, SendPartyMessage,
+            SendTellMessage, ServerChatIpcData, ServerChatIpcSegment, TellMessage,
+            TellNotFoundError,
         },
         zone::{CrossworldLinkshellEx, OnlineStatus},
     },
@@ -332,6 +333,35 @@ impl ChatConnection {
                 self.chatchannels.cwls[index].channel_number = shell.ids.linkshell_id as u32;
             }
         }
+    }
+
+    pub async fn send_dice_roll(&mut self, roll_data: ChatDiceRollData) {
+        let (num_sides, roll_result) = roll_die(roll_data.num_sides);
+
+        let result = ChatDiceRollResult {
+            community_id: roll_data.community_id,
+            account_id: self.player_data.account_id,
+            content_id: self.player_data.content_id,
+            roll_result,
+            num_sides,
+            world_id: self.config.world_id,
+            unk1: roll_data.unk2,
+            unk2: roll_data.unk1,
+            character_name: self.player_data.name.clone(),
+        };
+
+        self.handle
+            .send(ToServer::ChatDiceRoll(self.player_data.actor_id, result))
+            .await;
+    }
+
+    pub async fn dice_roll_received(
+        &mut self,
+        from_actor_id: ObjectId,
+        result: ChatDiceRollResult,
+    ) {
+        let ipc = ServerChatIpcSegment::new(ServerChatIpcData::ChatDiceRollResult(result));
+        self.send_ipc_from(from_actor_id, ipc).await;
     }
 
     pub async fn set_party_chatchannel(&mut self, party_channel_number: u32) {

--- a/servers/world/src/common.rs
+++ b/servers/world/src/common.rs
@@ -22,14 +22,16 @@ use kawari::{
         WeaponModelId,
     },
     ipc::{
-        chat::{CWLinkshellMessage, ChatChannelType, PartyMessage, TellMessage},
+        chat::{
+            CWLinkshellMessage, ChatChannelType, ChatDiceRollResult, PartyMessage, TellMessage,
+        },
         zone::{
             ActionRequest, ActorControlCategory, CWLSLeaveReason, CWLSPermissionRank,
             ClientTrigger, Conditions, Config, CrossworldLinkshellInvite, DutyFinderSetting,
             InviteReply, InviteType, OnlineStatus, PartyMemberEntry, PartyMemberPositions,
             PartyUpdateStatus, ReadyCheckReply, ServerZoneIpcSegment, SpawnNpc, SpawnObject,
             SpawnPlayer, SpawnTreasure, StrategyBoard, StrategyBoardUpdate, WaymarkPlacementMode,
-            WaymarkPosition, WaymarkPreset,
+            WaymarkPosition, WaymarkPreset, ZoneDiceRollResult,
         },
     },
 };
@@ -241,6 +243,10 @@ pub enum FromServer {
     CheckTeleportSharingEligibility(u32),
     /// Inform the client of their player's new CharacterMode.
     SetCharacterMode(CharacterMode, u8),
+    /// Inform the chat connection that someone (or their own player) in one of their ChatChannels sent a dice roll.
+    ChatDiceRoll(ObjectId, ChatDiceRollResult),
+    /// Inform the zone connection that someone (or their own player) in the vicinity sent a dice roll.
+    ZoneDiceRoll(ObjectId, ZoneDiceRollResult),
 }
 
 #[derive(Debug, Clone)]
@@ -489,6 +495,10 @@ pub enum ToServer {
     EnterTerritoryEvent(ObjectId),
     /// This player is now ready for the instanced content to begin.
     ReadyToCommence(ObjectId),
+    /// The client uses the /dice command to send a dice roll to one of their ChatChannels.
+    ChatDiceRoll(ObjectId, ChatDiceRollResult),
+    /// The client uses the /random command to send a dice roll to nearby players in the vicinity.
+    ZoneDiceRoll(ObjectId, ZoneDiceRollResult),
 }
 
 #[derive(Clone, Debug)]
@@ -540,4 +550,26 @@ where
     }
 
     ret
+}
+
+/// Rolls an n-sided die, up to n = 999 inclusive.
+pub fn roll_die(num_sides: u16) -> (u16, u16) {
+    let mut sides_clamped = num_sides;
+
+    // We can't use the standard clamp for this: when the side count is 0, it means the client wants the default of 999 sides.
+    // This does matter: it causes the client to display different text.
+    // Examples:
+    // /dice will display {Random! <some value from 1-999>} (in the client-sent packet, the number of sides specified would be 0, and the server will also send back 0 sides).
+    // /dice 999 will display {Random! <some value from 1-999> (1-999)}.
+    // /dice 456 will display {Random! <some value from 1-456> (1-456)}.
+    if !(1..=999).contains(&sides_clamped) {
+        sides_clamped = 999;
+    }
+
+    // We do a clamp here from 0-999 inclusive to ensure the client will display the correct text, as described above.
+    let sides_result = num_sides.clamp(0, 999);
+
+    let roll_result = fastrand::u16(1..sides_clamped + 1); // +1 since this range is exclusive, and we *do* allow the maximum value to be rolled.
+
+    (sides_result, roll_result)
 }

--- a/servers/world/src/main.rs
+++ b/servers/world/src/main.rs
@@ -415,6 +415,9 @@ async fn client_chat_loop(
                                             ClientChatIpcData::SendAllianceMessage(_data) => {
                                                 tracing::info!("Chatting in alliances is unimplemented");
                                             }
+                                            ClientChatIpcData::DiceRollCWLS(data) | ClientChatIpcData::DiceRollParty(data) => {
+                                                connection.send_dice_roll(*data).await;
+                                            }
                                             ClientChatIpcData::Unknown { unk } => {
                                                 tracing::warn!("Unknown chat packet {:?} recieved ({} bytes)", data.header.op_code, unk.len());
                                             }
@@ -447,6 +450,7 @@ async fn client_chat_loop(
                     FromServer::PartyMessageReceived(message_data) => connection.party_message_received(message_data).await,
                     FromServer::MustRefreshChatChannels => connection.refresh_chatchannels().await,
                     FromServer::CWLSMessageReceived(message_info) => connection.cwls_message_received(message_info).await,
+                    FromServer::ChatDiceRoll(from_actor_id, roll_data) => connection.dice_roll_received(from_actor_id, roll_data).await,
                     _ => tracing::error!("ChatConnection {:#?} received a FromServer message we don't care about: {:#?}, ensure you're using the right client network or that you've implemented a handler for it if we actually care about it!", client_handle.id, msg),
                 },
                 None => break,
@@ -1790,6 +1794,9 @@ async fn process_packet(
                                             )
                                             .await;
                                     }
+                                }
+                                ClientTriggerCommand::ZoneDiceRoll { num_sides } => {
+                                    connection.send_dice_roll(num_sides as u16).await;
                                 }
                                 _ => {
                                     // inform the server of our trigger, it will handle sending it to other clients
@@ -4340,6 +4347,11 @@ async fn process_server_msg(
             }
             FromServer::SetCharacterMode(mode, arg) => {
                 connection.set_character_mode(mode, arg, false).await;
+            }
+            FromServer::ZoneDiceRoll(from_actor_id, roll_data) => {
+                connection
+                    .dice_roll_received(from_actor_id, roll_data)
+                    .await;
             }
             _ => {
                 tracing::error!(

--- a/servers/world/src/server/social.rs
+++ b/servers/world/src/server/social.rs
@@ -6,7 +6,8 @@ use crate::{
     FromServer, ToServer,
     server::{DestinationNetwork, WorldServer, network::NetworkState},
 };
-use kawari::{common::LogMessageType, ipc::zone::InviteType};
+
+use kawari::{common::LogMessageType, ipc::chat::ChatChannelType, ipc::zone::InviteType};
 
 /// Process social invitation and moogle mail-related messages.
 pub fn handle_social_messages(
@@ -159,6 +160,56 @@ pub fn handle_social_messages(
                 FromServer::NewLetterArrived,
                 DestinationNetwork::ZoneClients,
             );
+
+            true
+        }
+        ToServer::ChatDiceRoll(from_actor_id, roll_data) => {
+            let mut network = network.lock();
+            let msg = FromServer::ChatDiceRoll(*from_actor_id, roll_data.clone());
+
+            match roll_data.community_id.channel_type {
+                ChatChannelType::CWLinkshell => {
+                    network.send_to_linkshell(
+                        roll_data.community_id.channel_number as u64,
+                        None,
+                        msg,
+                        DestinationNetwork::ChatClients,
+                    );
+                }
+                ChatChannelType::Party => {
+                    let Some(id) = network.parties.iter().find_map(|(key, val)| {
+                        (val.chatchannel_id == roll_data.community_id.channel_number).then_some(key)
+                    }) else {
+                        return true;
+                    };
+
+                    let party_id = *id;
+
+                    network.send_to_party(party_id, None, msg, DestinationNetwork::ChatClients);
+                }
+                _ => {
+                    tracing::warn!(
+                        "Unimplemented dice roll channel: {:?}, we should implement this when possible!",
+                        roll_data.community_id.channel_type
+                    );
+                }
+            }
+
+            true
+        }
+        ToServer::ZoneDiceRoll(from_actor_id, roll_data) => {
+            let mut network = network.lock();
+            let data = data.lock();
+
+            if let Some(instance) = data.find_actor_instance(*from_actor_id) {
+                let msg = FromServer::ZoneDiceRoll(*from_actor_id, roll_data.clone());
+                network.send_in_range_inclusive_instance(
+                    *from_actor_id,
+                    instance,
+                    msg,
+                    DestinationNetwork::ZoneClients,
+                );
+            }
 
             true
         }

--- a/servers/world/src/zone_connection/social.rs
+++ b/servers/world/src/zone_connection/social.rs
@@ -1,11 +1,11 @@
 //! Other social features, as well as invite sending and replies.
-use crate::{ToServer, ZoneConnection};
+use crate::{ToServer, ZoneConnection, common::roll_die};
 use kawari::{
-    common::{LogMessageType, timestamp_secs},
+    common::{LogMessageType, ObjectId, timestamp_secs},
     ipc::zone::{
         InviteReply, InviteType, InviteUpdateType, OnlineStatus, OnlineStatusMask, PlayerEntry,
         SearchUIClassJobMask, SearchUIGrandCompanies, ServerZoneIpcData, ServerZoneIpcSegment,
-        SocialList, SocialListRequestType, SocialListUILanguages,
+        SocialList, SocialListRequestType, SocialListUILanguages, ZoneDiceRollResult,
     },
 };
 
@@ -514,5 +514,36 @@ impl ZoneConnection {
             num_results: self.search_results.len() as u32,
         });
         self.send_ipc_self(ipc).await;
+    }
+
+    pub async fn send_dice_roll(&mut self, num_sides: u16) {
+        let (roll_maximum, roll_result) = roll_die(num_sides);
+
+        let result = ZoneDiceRollResult {
+            account_id: self.player_data.character.service_account_id as u64,
+            content_id: self.player_data.character.content_id as u64,
+            actor_id: self.player_data.character.actor_id,
+            world_id: self.config.world_id,
+            roll_result,
+            num_sides: roll_maximum,
+            unk: 0x100,
+            name: self.player_data.character.name.clone(),
+        };
+
+        self.handle
+            .send(ToServer::ZoneDiceRoll(
+                self.player_data.character.actor_id,
+                result,
+            ))
+            .await;
+    }
+
+    pub async fn dice_roll_received(
+        &mut self,
+        from_actor_id: ObjectId,
+        result: ZoneDiceRollResult,
+    ) {
+        let ipc = ServerZoneIpcSegment::new(ServerZoneIpcData::ZoneDiceRollResult(result));
+        self.send_ipc_from(from_actor_id, ipc).await;
     }
 }


### PR DESCRIPTION
This PR adds initial support for the `/dice` and `/random` commands, which both generate a random number from 1 to num_sides (inclusive), where num_sides is a number the player can specify (or if left unspecified, the server defaults to 999).

For those not in the know: `/random` is used to publicly broadcast a dice roll in `/say` range, while `/dice` is used to broadcast it privately to a linkshell, cross-world linkshell, free company, or party (and maybe alliance, can't check yet, and we can't implement that yet anyway).